### PR TITLE
fix(Response): correctly send the response when file doesn't exist while streaming it

### DIFF
--- a/src/Response/index.ts
+++ b/src/Response/index.ts
@@ -269,7 +269,7 @@ export class Response extends Macroable implements ResponseContract {
        * Listen for errors on the stream and properly destroy
        * stream
        */
-      body.on('error', (error) => {
+      body.on('error', (error: NodeJS.ErrnoException) => {
         /* istanbul ignore if */
         if (finished) {
           return
@@ -283,7 +283,7 @@ export class Response extends Macroable implements ResponseContract {
         } else {
           this._end(
             error.code === 'ENOENT' ? 'File not found' : 'Cannot process file',
-            error.status || 500,
+            error.code === 'ENOENT' ? 404 : 500,
           )
           resolve()
         }

--- a/test/response.spec.ts
+++ b/test/response.spec.ts
@@ -396,6 +396,19 @@ test.group('Response', (group) => {
     assert.equal(text, 'hello world')
   })
 
+  test('raise error when we try to stream a non-existing file', async (assert) => {
+    const server = createServer((req, res) => {
+      const config = fakeConfig()
+      const response = new Response(req, res, config)
+      response.stream(createReadStream(join(fs.basePath, 'i-dont-exist.txt')))
+      response.finish()
+    })
+
+    const { text, status } = await supertest(server).get('/')
+    assert.equal(status, 404)
+    assert.equal(text, 'File not found')
+  })
+
   test('raise error when input is not a stream', async (assert) => {
     assert.plan(1)
 


### PR DESCRIPTION
## Proposed changes

It seems that the correct type for the `error` variable created inside a stream callback is `NodeJS.ErrnoException`.

Therefor, this type doesn't have any `status` property, this means we cannot use it to send back the status.

## Types of changes

I have corrected the type in the callback and added a test to ensure no regression and that the change fixed an actual bug (before, the status was always 500).

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/http-server/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
