### PR TITLE
fix(response): use never return type for abort method

### DIFF
--- a/adonis-typings/response.ts
+++ b/adonis-typings/response.ts
@@ -101,7 +101,7 @@ declare module '@ioc:Adonis/Core/Response' {
     plainCookie (key: string, value: any, options?: Partial<CookieOptions>): this
     clearCookie (key: string): this
 
-    abort (body: any, status?: number): void
+    abort (body: any, status?: number): never
     abortIf (conditional: any, body: any, status?: number): void
 
     finish (): void

--- a/adonis-typings/response.ts
+++ b/adonis-typings/response.ts
@@ -103,6 +103,7 @@ declare module '@ioc:Adonis/Core/Response' {
 
     abort (body: any, status?: number): never
     abortIf (conditional: any, body: any, status?: number): void
+    abortUnless (conditional: any, body: any, status?: number): asserts conditional
 
     finish (): void
   }

--- a/src/Response/index.ts
+++ b/src/Response/index.ts
@@ -819,7 +819,7 @@ export class Response extends Macroable implements ResponseContract {
    * Abort the request with custom body and a status code. 400 is
    * used when status is not defined
    */
-  public abort (body: any, status?: number): void {
+  public abort (body: any, status?: number): never {
     throw HttpException.invoke(body, status || 400)
   }
 

--- a/src/Response/index.ts
+++ b/src/Response/index.ts
@@ -834,6 +834,16 @@ export class Response extends Macroable implements ResponseContract {
   }
 
   /**
+   * Abort the request with custom body and a status code when
+   * passed condition returns `false`
+   */
+  public abortUnless (condition: any, body: any, status?: number): asserts condition {
+    if (!condition) {
+      this.abort(body, status)
+    }
+  }
+
+  /**
    * Set signed cookie as the response header. The inline options overrides
    * all options from the config (means they are not merged).
    */

--- a/test/response.spec.ts
+++ b/test/response.spec.ts
@@ -1034,7 +1034,7 @@ test.group('Response', (group) => {
     assert.deepEqual(body, { message: 'Not allowed' })
   })
 
-  test('abort request when condition is truthy', async (assert) => {
+  test('abortIf: abort request when condition is truthy', async (assert) => {
     const server = createServer((req, res) => {
       const config = fakeConfig()
       const response = new Response(req, res, config)
@@ -1051,12 +1051,45 @@ test.group('Response', (group) => {
     assert.deepEqual(body, { message: 'Not allowed' })
   })
 
-  test('do not abort request when condition is falsy', async () => {
+  test('abortIf: do not abort request when condition is falsy', async () => {
     const server = createServer((req, res) => {
       const config = fakeConfig()
       const response = new Response(req, res, config)
       try {
         response.abortIf(false, { message: 'Not allowed' }, 401)
+      } catch (error) {
+        error.handle(error, { response })
+      }
+
+      response.finish()
+    })
+
+    await supertest(server).get('/').expect(200)
+  })
+
+  test('abortUnless: abort request when condition is falsy', async (assert) => {
+    const server = createServer((req, res) => {
+      const config = fakeConfig()
+      const response: Response = new Response(req, res, config)
+      try {
+        response.abortUnless(false, { message: 'Not allowed' }, 401)
+      } catch (error) {
+        error.handle(error, { response })
+      }
+
+      response.finish()
+    })
+
+    const { body } = await supertest(server).get('/').expect(401)
+    assert.deepEqual(body, { message: 'Not allowed' })
+  })
+
+  test('abortUnless: do not abort request when condition is truthy', async () => {
+    const server = createServer((req, res) => {
+      const config = fakeConfig()
+      const response: Response = new Response(req, res, config)
+      try {
+        response.abortUnless(true, { message: 'Not allowed' }, 401)
       } catch (error) {
         error.handle(error, { response })
       }


### PR DESCRIPTION
I tried to use the new feature that TypeScript added for assertions functions to fix the type of `abortIf` but couldn't find a way. `abortIf` is implemented in the opposite way (throws if the condition is truthy) than usual assertions.

Ref: https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#assertion-functions