### PR TITLE
fix: allow body in 201 created responses

### DIFF
--- a/adonis-typings/response.ts
+++ b/adonis-typings/response.ts
@@ -372,7 +372,7 @@ declare module '@ioc:Adonis/Core/Response' {
 		continue(): void
 		switchingProtocols(): void
 		ok(body: any, generateEtag?: boolean): void
-		created(): void
+		created(body?: any, generateEtag?: boolean): void
 		accepted(body: any, generateEtag?: boolean): void
 		nonAuthoritativeInformation(body: any, generateEtag?: boolean): void
 		noContent(): void

--- a/src/Response/index.ts
+++ b/src/Response/index.ts
@@ -926,9 +926,9 @@ export class Response extends Macroable implements ResponseContract {
 		return this.send(body, generateEtag)
 	}
 
-	public created(): void {
+	public created(body?: any, generateEtag?: boolean): void {
 		this.status(201)
-		return this.send(null, false)
+		return this.send(body, generateEtag)
 	}
 
 	public accepted(body: any, generateEtag?: boolean): void {


### PR DESCRIPTION
RFC allows a payload: https://tools.ietf.org/html/rfc7231#section-6.3.2
Example in the GitHub API: https://docs.github.com/en/rest/reference/issues#create-an-issue
