### PR TITLE
fix(router): adding support for HEAD HTTP method for all GET routes back to v5

### DIFF
--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            November 24th 2020, 7:06:37 pm
+                            January 31st 2021, 6:53:36 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/src/Router/BriskRoute.ts
+++ b/src/Router/BriskRoute.ts
@@ -58,7 +58,7 @@ export class BriskRoute extends Macroable implements BriskRouteContract {
 			)
 		}
 
-		this.route = new Route(this.pattern, methods || ['GET'], handler, this.globalMatchers)
+		this.route = new Route(this.pattern, methods || ['HEAD', 'GET'], handler, this.globalMatchers)
 		this.invokedBy = invokedBy
 		return this.route
 	}

--- a/src/Router/Resource.ts
+++ b/src/Router/Resource.ts
@@ -78,11 +78,11 @@ export class RouteResource extends Macroable implements RouteResourceContract {
 			.map((token) => `${token}/:${lodash.snakeCase(singular(token))}_id`)
 			.join('/')}/${mainResource}`
 
-		this.makeRoute(fullUrl, ['GET'], 'index')
-		this.makeRoute(`${fullUrl}/create`, ['GET'], 'create')
+		this.makeRoute(fullUrl, ['HEAD', 'GET'], 'index')
+		this.makeRoute(`${fullUrl}/create`, ['HEAD', 'GET'], 'create')
 		this.makeRoute(fullUrl, ['POST'], 'store')
-		this.makeRoute(`${this.shallow ? mainResource : fullUrl}/:id`, ['GET'], 'show')
-		this.makeRoute(`${this.shallow ? mainResource : fullUrl}/:id/edit`, ['GET'], 'edit')
+		this.makeRoute(`${this.shallow ? mainResource : fullUrl}/:id`, ['HEAD', 'GET'], 'show')
+		this.makeRoute(`${this.shallow ? mainResource : fullUrl}/:id/edit`, ['HEAD', 'GET'], 'edit')
 		this.makeRoute(`${this.shallow ? mainResource : fullUrl}/:id`, ['PUT', 'PATCH'], 'update')
 		this.makeRoute(`${this.shallow ? mainResource : fullUrl}/:id`, ['DELETE'], 'destroy')
 	}

--- a/src/Router/index.ts
+++ b/src/Router/index.ts
@@ -140,7 +140,7 @@ export class Router implements RouterContract {
 	 * Define `GET` route
 	 */
 	public get(pattern: string, handler: RouteHandler): Route {
-		return this.route(pattern, ['GET'], handler)
+		return this.route(pattern, ['HEAD', 'GET'], handler)
 	}
 
 	/**

--- a/test/brisk-route.spec.ts
+++ b/test/brisk-route.spec.ts
@@ -23,7 +23,7 @@ test.group('Brisk Route', () => {
 			meta: {
 				namespace: undefined,
 			},
-			methods: ['GET'],
+			methods: ['HEAD', 'GET'],
 			middleware: [],
 			name: undefined,
 			pattern: '/',

--- a/test/group.spec.ts
+++ b/test/group.spec.ts
@@ -145,7 +145,7 @@ test.group('Route Group', () => {
 				meta: {
 					namespace: undefined,
 				},
-				methods: ['GET'],
+				methods: ['HEAD', 'GET'],
 				domain: 'root',
 				middleware: [],
 				handler: 'PhotosController.index',
@@ -157,7 +157,7 @@ test.group('Route Group', () => {
 				meta: {
 					namespace: undefined,
 				},
-				methods: ['GET'],
+				methods: ['HEAD', 'GET'],
 				domain: 'root',
 				middleware: [],
 				handler: 'PhotosController.create',
@@ -181,7 +181,7 @@ test.group('Route Group', () => {
 				meta: {
 					namespace: undefined,
 				},
-				methods: ['GET'],
+				methods: ['HEAD', 'GET'],
 				domain: 'root',
 				middleware: [],
 				handler: 'PhotosController.show',
@@ -193,7 +193,7 @@ test.group('Route Group', () => {
 				meta: {
 					namespace: undefined,
 				},
-				methods: ['GET'],
+				methods: ['HEAD', 'GET'],
 				domain: 'root',
 				middleware: [],
 				handler: 'PhotosController.edit',
@@ -238,7 +238,7 @@ test.group('Route Group', () => {
 				meta: {
 					namespace: undefined,
 				},
-				methods: ['GET'],
+				methods: ['HEAD', 'GET'],
 				domain: 'root',
 				middleware: [],
 				handler: 'PhotosController.index',
@@ -250,7 +250,7 @@ test.group('Route Group', () => {
 				meta: {
 					namespace: undefined,
 				},
-				methods: ['GET'],
+				methods: ['HEAD', 'GET'],
 				domain: 'root',
 				middleware: [],
 				handler: 'PhotosController.create',
@@ -274,7 +274,7 @@ test.group('Route Group', () => {
 				meta: {
 					namespace: undefined,
 				},
-				methods: ['GET'],
+				methods: ['HEAD', 'GET'],
 				domain: 'root',
 				middleware: [],
 				handler: 'PhotosController.show',
@@ -286,7 +286,7 @@ test.group('Route Group', () => {
 				meta: {
 					namespace: undefined,
 				},
-				methods: ['GET'],
+				methods: ['HEAD', 'GET'],
 				domain: 'root',
 				middleware: [],
 				handler: 'PhotosController.edit',

--- a/test/resource.spec.ts
+++ b/test/resource.spec.ts
@@ -23,7 +23,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'PhotosController.index',
@@ -35,7 +35,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'PhotosController.create',
@@ -59,7 +59,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'PhotosController.show',
@@ -71,7 +71,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'PhotosController.edit',
@@ -117,7 +117,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'AdsController.index',
@@ -129,7 +129,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'AdsController.create',
@@ -153,7 +153,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'AdsController.show',
@@ -165,7 +165,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'AdsController.edit',
@@ -211,7 +211,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'AdsController.index',
@@ -223,7 +223,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'AdsController.create',
@@ -247,7 +247,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'AdsController.show',
@@ -259,7 +259,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'AdsController.edit',
@@ -436,7 +436,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'PhotosController.index',
@@ -448,7 +448,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'PhotosController.create',
@@ -472,7 +472,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'PhotosController.show',
@@ -484,7 +484,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'PhotosController.edit',
@@ -530,7 +530,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'ProfileController.index',
@@ -542,7 +542,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'ProfileController.create',
@@ -566,7 +566,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'ProfileController.show',
@@ -578,7 +578,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'ProfileController.edit',
@@ -624,7 +624,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'CommentsController.index',
@@ -636,7 +636,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'CommentsController.create',
@@ -660,7 +660,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'CommentsController.show',
@@ -672,7 +672,7 @@ test.group('Route Resource', () => {
 					meta: {
 						namespace: undefined,
 					},
-					methods: ['GET'],
+					methods: ['HEAD', 'GET'],
 					domain: 'root',
 					middleware: [],
 					handler: 'CommentsController.edit',

--- a/test/router.spec.ts
+++ b/test/router.spec.ts
@@ -41,7 +41,7 @@ test.group('Router | add', () => {
 
 		assert.deepEqual(getRoute.toJSON(), {
 			pattern: '/',
-			methods: ['GET'],
+			methods: ['HEAD', 'GET'],
 			meta: {
 				namespace: undefined,
 			},
@@ -201,6 +201,35 @@ test.group('Router | add', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/api/v1',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+								{
+									old: '/api/v1',
+									type: 0,
+									val: 'v1',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/api/v1': {
+								pattern: '/api/v1',
+								handler,
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: undefined,
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -266,6 +295,29 @@ test.group('Router | add', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/',
+									type: 0,
+									val: '/',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/': {
+								pattern: '/',
+								handler,
+								meta: {
+									namespace: undefined,
+								},
+								middleware: ['auth', 'admin:acl'],
+								name: undefined,
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -325,6 +377,29 @@ test.group('Router | add', () => {
 			],
 			domains: {
 				'foo.com': {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/',
+									type: 0,
+									val: '/',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/': {
+								pattern: '/',
+								handler,
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: undefined,
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -384,6 +459,29 @@ test.group('Router | add', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/',
+									type: 0,
+									val: '/',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/': {
+								pattern: '/',
+								handler,
+								meta: {
+									namespace: 'User',
+								},
+								middleware: [],
+								name: undefined,
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -444,6 +542,37 @@ test.group('Router | add', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/:user_id/:id',
+									type: 1,
+									val: 'user_id',
+									end: '',
+									matcher: /[0-9]/,
+								},
+								{
+									old: '/:user_id/:id',
+									type: 1,
+									val: 'id',
+									end: '',
+									matcher: /[a-z]/,
+								},
+							],
+						],
+						routes: {
+							'/:user_id/:id': {
+								pattern: '/:user_id/:id',
+								handler,
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: undefined,
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -511,6 +640,29 @@ test.group('Router | add', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/',
+									type: 0,
+									val: '/',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/': {
+								pattern: '/',
+								handler,
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'api.admin.home',
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -561,6 +713,29 @@ test.group('Router | commit', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/',
+									type: 0,
+									val: '/',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/': {
+								pattern: '/',
+								handler,
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: undefined,
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -614,6 +789,29 @@ test.group('Router | commit', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/api',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/api': {
+								pattern: '/api',
+								handler,
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: undefined,
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -666,6 +864,130 @@ test.group('Router | commit', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/api/posts',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+								{
+									old: '/api/posts',
+									type: 0,
+									val: 'posts',
+									end: '',
+								},
+							],
+							[
+								{
+									old: '/api/posts/create',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+								{
+									old: '/api/posts/create',
+									type: 0,
+									val: 'posts',
+									end: '',
+								},
+								{
+									old: '/api/posts/create',
+									type: 0,
+									val: 'create',
+									end: '',
+								},
+							],
+							[
+								{
+									old: '/api/posts/:id',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+								{
+									old: '/api/posts/:id',
+									type: 0,
+									val: 'posts',
+									end: '',
+								},
+								{
+									old: '/api/posts/:id',
+									type: 1,
+									val: 'id',
+									end: '',
+									matcher: undefined,
+								},
+							],
+							[
+								{
+									old: '/api/posts/:id/edit',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+								{
+									old: '/api/posts/:id/edit',
+									type: 0,
+									val: 'posts',
+									end: '',
+								},
+								{
+									old: '/api/posts/:id/edit',
+									type: 1,
+									val: 'id',
+									end: '',
+									matcher: undefined,
+								},
+								{
+									old: '/api/posts/:id/edit',
+									type: 0,
+									val: 'edit',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/api/posts': {
+								pattern: '/api/posts',
+								handler: 'PostController.index',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.index',
+							},
+							'/api/posts/create': {
+								pattern: '/api/posts/create',
+								handler: 'PostController.create',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.create',
+							},
+							'/api/posts/:id': {
+								pattern: '/api/posts/:id',
+								handler: 'PostController.show',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.show',
+							},
+							'/api/posts/:id/edit': {
+								pattern: '/api/posts/:id/edit',
+								handler: 'PostController.edit',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.edit',
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -960,6 +1282,154 @@ test.group('Router | commit', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/api/v1/posts',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts',
+									type: 0,
+									val: 'v1',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts',
+									type: 0,
+									val: 'posts',
+									end: '',
+								},
+							],
+							[
+								{
+									old: '/api/v1/posts/create',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts/create',
+									type: 0,
+									val: 'v1',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts/create',
+									type: 0,
+									val: 'posts',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts/create',
+									type: 0,
+									val: 'create',
+									end: '',
+								},
+							],
+							[
+								{
+									old: '/api/v1/posts/:id',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts/:id',
+									type: 0,
+									val: 'v1',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts/:id',
+									type: 0,
+									val: 'posts',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts/:id',
+									type: 1,
+									val: 'id',
+									end: '',
+									matcher: undefined,
+								},
+							],
+							[
+								{
+									old: '/api/v1/posts/:id/edit',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts/:id/edit',
+									type: 0,
+									val: 'v1',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts/:id/edit',
+									type: 0,
+									val: 'posts',
+									end: '',
+								},
+								{
+									old: '/api/v1/posts/:id/edit',
+									type: 1,
+									val: 'id',
+									end: '',
+									matcher: undefined,
+								},
+								{
+									old: '/api/v1/posts/:id/edit',
+									type: 0,
+									val: 'edit',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/api/v1/posts': {
+								pattern: '/api/v1/posts',
+								handler: 'PostController.index',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.index',
+							},
+							'/api/v1/posts/create': {
+								pattern: '/api/v1/posts/create',
+								handler: 'PostController.create',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.create',
+							},
+							'/api/v1/posts/:id': {
+								pattern: '/api/v1/posts/:id',
+								handler: 'PostController.show',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.show',
+							},
+							'/api/v1/posts/:id/edit': {
+								pattern: '/api/v1/posts/:id/edit',
+								handler: 'PostController.edit',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.edit',
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -1293,6 +1763,132 @@ test.group('Router | commit', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/posts/:post_id/comments',
+									type: 0,
+									val: 'posts',
+									end: '',
+								},
+								{
+									old: '/posts/:post_id/comments',
+									type: 1,
+									val: 'post_id',
+									matcher: undefined,
+									end: '',
+								},
+								{
+									old: '/posts/:post_id/comments',
+									type: 0,
+									val: 'comments',
+									end: '',
+								},
+							],
+							[
+								{
+									old: '/posts/:post_id/comments/create',
+									type: 0,
+									val: 'posts',
+									end: '',
+								},
+								{
+									old: '/posts/:post_id/comments/create',
+									type: 1,
+									val: 'post_id',
+									end: '',
+									matcher: undefined,
+								},
+								{
+									old: '/posts/:post_id/comments/create',
+									type: 0,
+									val: 'comments',
+									end: '',
+								},
+								{
+									old: '/posts/:post_id/comments/create',
+									type: 0,
+									val: 'create',
+									end: '',
+								},
+							],
+							[
+								{
+									old: '/comments/:id',
+									type: 0,
+									val: 'comments',
+									end: '',
+								},
+								{
+									old: '/comments/:id',
+									type: 1,
+									val: 'id',
+									end: '',
+									matcher: undefined,
+								},
+							],
+							[
+								{
+									old: '/comments/:id/edit',
+									type: 0,
+									val: 'comments',
+									end: '',
+								},
+								{
+									old: '/comments/:id/edit',
+									type: 1,
+									val: 'id',
+									end: '',
+									matcher: undefined,
+								},
+								{
+									old: '/comments/:id/edit',
+									type: 0,
+									val: 'edit',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/posts/:post_id/comments': {
+								pattern: '/posts/:post_id/comments',
+								handler: 'CommentsController.index',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.comments.index',
+							},
+							'/posts/:post_id/comments/create': {
+								pattern: '/posts/:post_id/comments/create',
+								handler: 'CommentsController.create',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.comments.create',
+							},
+							'/comments/:id': {
+								pattern: '/comments/:id',
+								handler: 'CommentsController.show',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.comments.show',
+							},
+							'/comments/:id/edit': {
+								pattern: '/comments/:id/edit',
+								handler: 'CommentsController.edit',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'posts.comments.edit',
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -1589,6 +2185,35 @@ test.group('Router | commit', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/photos/create',
+									type: 0,
+									val: 'photos',
+									end: '',
+								},
+								{
+									old: '/photos/create',
+									type: 0,
+									val: 'create',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/photos/create': {
+								pattern: '/photos/create',
+								handler: 'PhotosController.create',
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'v1.photos.create',
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -1644,6 +2269,30 @@ test.group('Router | commit', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/',
+									type: 0,
+									val: '/',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/': {
+								pattern: '/',
+								handler: 'FooHandler.get',
+								meta: {
+									processed: true,
+									namespace: undefined,
+								},
+								middleware: [],
+								name: undefined,
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -1694,6 +2343,36 @@ test.group('Router | commit', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/photos/create',
+									type: 0,
+									val: 'photos',
+									end: '',
+								},
+								{
+									old: '/photos/create',
+									type: 0,
+									val: 'create',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/photos/create': {
+								pattern: '/photos/create',
+								handler: 'PhotosController.create',
+								meta: {
+									processed: true,
+									namespace: undefined,
+								},
+								middleware: [],
+								name: 'photos.create',
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -1752,6 +2431,30 @@ test.group('Router | commit', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/',
+									type: 0,
+									val: '/',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/': {
+								pattern: '/',
+								handler: 'FooHandler.get',
+								meta: {
+									processed: true,
+									namespace: undefined,
+								},
+								middleware: [],
+								name: undefined,
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -1802,6 +2505,30 @@ test.group('Router | commit', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/:id',
+									type: 1,
+									val: 'id',
+									end: '',
+									matcher: /^[a-z]+/,
+								},
+							],
+						],
+						routes: {
+							'/:id': {
+								pattern: '/:id',
+								handler,
+								meta: {
+									namespace: undefined,
+								},
+								middleware: [],
+								name: undefined,
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[
@@ -2054,7 +2781,7 @@ test.group('Brisk route', () => {
 				name: undefined,
 				pattern: '/',
 				handler,
-				methods: ['GET'],
+				methods: ['HEAD', 'GET'],
 				domain: 'root',
 			},
 		])
@@ -2077,7 +2804,7 @@ test.group('Brisk route', () => {
 				name: 'v1.root',
 				pattern: '/api/v1',
 				handler,
-				methods: ['GET'],
+				methods: ['HEAD', 'GET'],
 				domain: 'root',
 			},
 		])
@@ -2109,6 +2836,35 @@ test.group('Brisk route', () => {
 			],
 			domains: {
 				root: {
+					HEAD: {
+						tokens: [
+							[
+								{
+									old: '/api/v1',
+									type: 0,
+									val: 'api',
+									end: '',
+								},
+								{
+									old: '/api/v1',
+									type: 0,
+									val: 'v1',
+									end: '',
+								},
+							],
+						],
+						routes: {
+							'/api/v1': {
+								pattern: '/api/v1',
+								meta: {
+									namespace: undefined,
+								},
+								handler,
+								middleware: [],
+								name: 'v1.root',
+							},
+						},
+					},
 					GET: {
 						tokens: [
 							[


### PR DESCRIPTION
fix #2136

<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This PR is adding support for HEAD HTTP method for all GET routes back to v5 as discussed here: https://github.com/adonisjs/core/discussions/2136#discussioncomment-323935
Tests are modified as well

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/http-server/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
