### PR TITLE
fix: improve typings for object used as dictionaries

### DIFF
--- a/adonis-typings/context.ts
+++ b/adonis-typings/context.ts
@@ -32,8 +32,8 @@ declare module '@ioc:Adonis/Core/HttpContext' {
     profiler: ProfilerRowContract
     route?: RouteNode
     routeKey: string
-    params: any
-    subdomains: any
+    params: Record<string, any>
+    subdomains: Record<string, any>
   }
 
   /**
@@ -50,7 +50,7 @@ declare module '@ioc:Adonis/Core/HttpContext' {
      */
     create(
       routePattern: string,
-      routeParams: any,
+      routeParams: Record<string, any>,
       req?: IncomingMessage,
       res?: ServerResponse
     ): HttpContextContract

--- a/adonis-typings/request.ts
+++ b/adonis-typings/request.ts
@@ -48,14 +48,14 @@ declare module '@ioc:Adonis/Core/Request' {
      * This method is supposed to be invoked by the body parser and must be called only
      * once. For further mutations make use of `updateBody` method.
      */
-    setInitialBody(body: any): void
+    setInitialBody(body: Record<string, any>): void
 
     /**
      * Update the request body with new data object. The `all` property
      * will be re-computed by merging the query string and request
      * body.
      */
-    updateBody(body: any): void
+    updateBody(body: Record<string, any>): void
 
     /**
      * Update the request raw body. Bodyparser sets this when unable to parse
@@ -66,52 +66,52 @@ declare module '@ioc:Adonis/Core/Request' {
     /**
      * Update route params
      */
-    updateParams(body: any): void
+    updateParams(body: Record<string, any>): void
 
     /**
      * Update the query string with the new data object. The `all` property
      * will be re-computed by merging the query and the request body.
      */
-    updateQs(data: any): void
+    updateQs(data: Record<string, any>): void
 
     /**
      * Returns route params
      */
-    params(): { [key: string]: any }
+    params(): Record<string, any>
 
     /**
      * Returns reference to the query string object
      * @deprecated: Use ".qs()" instead
      */
-    get(): { [key: string]: any }
+    get(): Record<string, any>
 
     /**
      * Returns the query string object by reference
      */
-    qs(): { [key: string]: any }
+    qs(): Record<string, any>
 
     /**
      * Returns the request body object by reference
      * @deprecated: Use ".body()" instead
      */
-    post(): { [key: string]: any }
+    post(): Record<string, any>
 
     /**
      * Returns the request body object by reference
      */
-    body(): { [key: string]: any }
+    body(): Record<string, any>
 
     /**
      * Returns reference to the merged copy of original request
      * query string and body
      */
-    original(): { [key: string]: any }
+    original(): Record<string, any>
 
     /**
      * Returns reference to the merged copy of request body
      * and query string
      */
-    all(): { [key: string]: any }
+    all(): Record<string, any>
 
     /**
      * Returns the request raw body (if exists), or returns `null`.
@@ -156,7 +156,7 @@ declare module '@ioc:Adonis/Core/Request' {
      * request.except(['_csrf'])
      * ```
      */
-    except(keys: string[]): { [key: string]: any }
+    except(keys: string[]): Record<string, any>
 
     /**
      * Get value for specified keys.
@@ -540,7 +540,7 @@ declare module '@ioc:Adonis/Core/Request' {
      * Returns all parsed and signed cookies. Signed cookies ensures
      * that their value isn't tampered.
      */
-    cookiesList(): { [key: string]: any }
+    cookiesList(): Record<string, any>
 
     /**
      * Returns value for a given key from signed cookies. Optional

--- a/adonis-typings/response.ts
+++ b/adonis-typings/response.ts
@@ -437,7 +437,7 @@ declare module '@ioc:Adonis/Core/Response' {
      * Forward the current QueryString or define one.
      */
     withQs(): this
-    withQs(values: { [key: string]: any }): this
+    withQs(values: Record<string, any>): this
     withQs(name: string, value: any): this
 
     /**

--- a/adonis-typings/route.ts
+++ b/adonis-typings/route.ts
@@ -91,7 +91,7 @@ declare module '@ioc:Adonis/Core/Route' {
       resolvedHandler?: ResolvedRouteHandler
       resolvedMiddleware?: ResolvedMiddlewareHandler[]
       namespace?: string
-    } & { [key: string]: any }
+    } & Record<string, any>
 
     /**
      * A unique name to lookup routes by name
@@ -164,8 +164,8 @@ declare module '@ioc:Adonis/Core/Route' {
      * A unique key for the looked up route
      */
     routeKey: string
-    params: any
-    subdomains: any
+    params: Record<string, any>
+    subdomains: Record<string, any>
   }
 
   /**
@@ -394,7 +394,7 @@ declare module '@ioc:Adonis/Core/Route' {
      */
     redirect(
       identifier: string,
-      params?: any[] | { [key: string]: any },
+      params?: any[] | Record<string, any>,
       options?: MakeUrlOptions
     ): RouteContract
 
@@ -416,10 +416,10 @@ declare module '@ioc:Adonis/Core/Route' {
    * Options accepted by makeUrl methods
    */
   export type MakeUrlOptions = {
-    qs?: { [key: string]: any }
+    qs?: Record<string, any>
     domain?: string
     prefixUrl?: string
-  } & { [key: string]: any }
+  } & Record<string, any>
 
   /**
    * Options for making a signed url
@@ -597,12 +597,12 @@ declare module '@ioc:Adonis/Core/Route' {
     /**
      * Prefix a custom url to the final URI
      */
-    params(params: undefined | any[] | { [key: string]: any }): this
+    params(params?: any[] | Record<string, any>): this
 
     /**
      * Append query string to the final URI
      */
-    qs(qs: undefined | { [key: string]: any }): this
+    qs(qs?: Record<string, any>): this
 
     /**
      * Define required params to resolve the route

--- a/src/Cookie/Parser/index.ts
+++ b/src/Cookie/Parser/index.ts
@@ -30,9 +30,9 @@ export class CookieParser {
    * initial decoding, unsigning or decrypting.
    */
   private cachedCookies: {
-    encryptedCookies: { [key: string]: any }
-    signedCookies: { [key: string]: any }
-    plainCookies: { [key: string]: any }
+    encryptedCookies: Record<string, any>
+    signedCookies: Record<string, any>
+    plainCookies: Record<string, any>
   } = {
     signedCookies: {},
     plainCookies: {},
@@ -43,7 +43,7 @@ export class CookieParser {
    * An object of key-value pair collected by parsing
    * the request cookie header.
    */
-  private cookies: { [key: string]: any } = this.parse()
+  private cookies: Record<string, any> = this.parse()
 
   constructor(private cookieHeader: string, private encryption: EncryptionContract) {}
 

--- a/src/HttpContext/index.ts
+++ b/src/HttpContext/index.ts
@@ -43,12 +43,12 @@ export class HttpContext extends Macroable implements HttpContextContract {
   /**
    * Route params
    */
-  public params: any = {}
+  public params: Record<string, any> = {}
 
   /**
    * Route subdomains
    */
-  public subdomains: any = {}
+  public subdomains: Record<string, any> = {}
 
   /**
    * Reference to the current route. Not available inside
@@ -93,7 +93,7 @@ export class HttpContext extends Macroable implements HttpContextContract {
    */
   public static create(
     routePattern: string,
-    routeParams: any,
+    routeParams: Record<string, any>,
     req?: IncomingMessage,
     res?: ServerResponse
   ) {

--- a/src/Redirect/index.ts
+++ b/src/Redirect/index.ts
@@ -33,7 +33,7 @@ export class Redirect implements RedirectContract {
   /**
    * A custom query string to forward
    */
-  private queryString: { [key: string]: any } = {}
+  private queryString: Record<string, any> = {}
 
   constructor(
     private request: IncomingMessage,
@@ -44,7 +44,7 @@ export class Redirect implements RedirectContract {
   /**
    * Sends response by setting require headers
    */
-  private sendResponse(url: string, query: any) {
+  private sendResponse(url: string, query: Record<string, any>) {
     const stringified = qs.stringify(query)
 
     url = stringified ? `${url}?${stringified}` : url
@@ -86,9 +86,9 @@ export class Redirect implements RedirectContract {
    * string.
    */
   public withQs(): this
-  public withQs(values: { [key: string]: any }): this
+  public withQs(values: Record<string, any>): this
   public withQs(name: string, value: any): this
-  public withQs(name?: { [key: string]: any } | string, value?: any): this {
+  public withQs(name?: Record<string, any> | string, value?: any): this {
     if (typeof name === 'undefined') {
       this.forwardQueryString = true
       return this
@@ -107,7 +107,7 @@ export class Redirect implements RedirectContract {
    * Redirect to the previous path.
    */
   public back() {
-    let query: any = {}
+    let query: Record<string, any> = {}
 
     const url = parse(this.getReferrerUrl())
 
@@ -150,7 +150,7 @@ export class Redirect implements RedirectContract {
    * Redirect the request using a path.
    */
   public toPath(url: string) {
-    let query: any = {}
+    let query: Record<string, any> = {}
 
     /**
      * Extract query string from the current URL

--- a/src/Request/index.ts
+++ b/src/Request/index.ts
@@ -41,28 +41,28 @@ export class Request extends Macroable implements RequestContract {
   /**
    * Request body set using `setBody` method
    */
-  private requestBody: object = {}
+  private requestBody: Record<string, any> = {}
 
   /**
    * Route params
    */
-  private routeParams: object = {}
+  private routeParams: Record<string, any> = {}
 
   /**
    * A merged copy of `request body` and `querystring`
    */
-  private requestData: object = {}
+  private requestData: Record<string, any> = {}
 
   /**
    * Original merged copy of `request body` and `querystring`.
    * Further mutation to this object are not allowed
    */
-  private originalRequestData: object = {}
+  private originalRequestData: Record<string, any> = {}
 
   /**
    * Parsed query string
    */
-  private requestQs: object = {}
+  private requestQs: Record<string, any> = {}
 
   /**
    * Raw request body as text
@@ -159,7 +159,7 @@ export class Request extends Macroable implements RequestContract {
    * This method is supposed to be invoked by the body parser and must be called only
    * once. For further mutations make use of `updateBody` method.
    */
-  public setInitialBody(body: object) {
+  public setInitialBody(body: Record<string, any>) {
     if (this.originalRequestData && Object.isFrozen(this.originalRequestData)) {
       throw new Error('Cannot re-set initial body. Use "request.updateBody" instead')
     }
@@ -177,7 +177,7 @@ export class Request extends Macroable implements RequestContract {
    * will be re-computed by merging the query string and request
    * body.
    */
-  public updateBody(body: object) {
+  public updateBody(body: Record<string, any>) {
     this.requestBody = body
     this.requestData = { ...this.requestBody, ...this.requestQs }
   }
@@ -194,7 +194,7 @@ export class Request extends Macroable implements RequestContract {
    * Update the query string with the new data object. The `all` property
    * will be re-computed by merging the query and the request body.
    */
-  public updateQs(data: object) {
+  public updateQs(data: Record<string, any>) {
     this.requestQs = data
     this.requestData = { ...this.requestBody, ...this.requestQs }
   }
@@ -202,21 +202,21 @@ export class Request extends Macroable implements RequestContract {
   /**
    * Update route params
    */
-  public updateParams(data: object) {
+  public updateParams(data: Record<string, any>) {
     this.routeParams = data
   }
 
   /**
    * Returns route params
    */
-  public params(): { [key: string]: any } {
+  public params(): Record<string, any> {
     return this.routeParams
   }
 
   /**
    * Returns reference to the query string object
    */
-  public get(): { [key: string]: any } {
+  public get(): Record<string, any> {
     process.emitWarning(
       'DeprecationWarning',
       'request.get() is deprecated. Use request.qs() instead'
@@ -227,14 +227,14 @@ export class Request extends Macroable implements RequestContract {
   /**
    * Returns the query string object by reference
    */
-  public qs(): { [key: string]: any } {
+  public qs(): Record<string, any> {
     return this.requestQs
   }
 
   /**
    * Returns reference to the request body
    */
-  public post(): { [key: string]: any } {
+  public post(): Record<string, any> {
     process.emitWarning(
       'DeprecationWarning',
       'request.post() is deprecated. Use request.body() instead'
@@ -245,7 +245,7 @@ export class Request extends Macroable implements RequestContract {
   /**
    * Returns reference to the request body
    */
-  public body(): { [key: string]: any } {
+  public body(): Record<string, any> {
     return this.requestBody
   }
 
@@ -253,7 +253,7 @@ export class Request extends Macroable implements RequestContract {
    * Returns reference to the merged copy of request body
    * and query string
    */
-  public all(): { [key: string]: any } {
+  public all(): Record<string, any> {
     return this.requestData
   }
 
@@ -261,7 +261,7 @@ export class Request extends Macroable implements RequestContract {
    * Returns reference to the merged copy of original request
    * query string and body
    */
-  public original(): { [key: string]: any } {
+  public original(): Record<string, any> {
     return this.originalRequestData
   }
 
@@ -314,7 +314,7 @@ export class Request extends Macroable implements RequestContract {
    * request.except(['_csrf'])
    * ```
    */
-  public except(keys: string[]): { [key: string]: any } {
+  public except(keys: string[]): Record<string, any> {
     return lodash.omit(this.requestData, keys)
   }
 

--- a/src/Router/BriskRoute.ts
+++ b/src/Router/BriskRoute.ts
@@ -74,7 +74,7 @@ export class BriskRoute extends Macroable implements BriskRouteContract {
    */
   public redirect(
     identifier: string,
-    params?: any[] | { [key: string]: any },
+    params?: any[] | Record<string, any>,
     options?: MakeUrlOptions
   ): Route {
     return this.setHandler(async (ctx) => {

--- a/src/Router/LookupStore.ts
+++ b/src/Router/LookupStore.ts
@@ -27,12 +27,12 @@ export class UrlBuilder implements UrlBuilderContract {
   /**
    * Params to be used for building the URL
    */
-  private routeParams: any[] | { [key: string]: any }
+  private routeParams: any[] | Record<string, any>
 
   /**
    * A custom query string to append to the URL
    */
-  private queryString: { [key: string]: any } = {}
+  private queryString: Record<string, any> = {}
 
   /**
    * A baseUrl to prefix to the endpoint
@@ -126,7 +126,7 @@ export class UrlBuilder implements UrlBuilderContract {
   /**
    * Append query string to the final URI
    */
-  public qs(queryString: undefined | { [key: string]: any }): this {
+  public qs(queryString?: Record<string, any>): this {
     if (!queryString) {
       return this
     }
@@ -137,7 +137,7 @@ export class UrlBuilder implements UrlBuilderContract {
   /**
    * Define required params to resolve the route
    */
-  public params(params: undefined | any[] | { [key: string]: any }): this {
+  public params(params?: any[] | Record<string, any>): this {
     if (!params) {
       return this
     }

--- a/src/Server/RequestHandler/index.ts
+++ b/src/Server/RequestHandler/index.ts
@@ -68,10 +68,10 @@ export class RequestHandler {
      * Attach `params`, `subdomains` and `route` when route is found. This
      * information only exists on a given route
      */
-    ctx.params = route!.params
-    ctx.subdomains = route!.subdomains
-    ctx.route = route!.route
-    ctx.routeKey = route!.routeKey
+    ctx.params = route.params
+    ctx.subdomains = route.subdomains
+    ctx.route = route.route
+    ctx.routeKey = route.routeKey
     ctx.request.updateParams(ctx.params)
   }
 


### PR DESCRIPTION
Replace `any` and `object` with `Record<string, any>`.
