### PR TITLE
fix: correct type of Request#only

### DIFF
--- a/adonis-typings/request.ts
+++ b/adonis-typings/request.ts
@@ -166,7 +166,7 @@ declare module '@ioc:Adonis/Core/Request' {
      * request.only(['username', 'age'])
      * ```
      */
-    only<T extends string, U = { [K in T]: any }>(keys: T[]): U
+    only<T extends string>(keys: T[]): { [K in T]: any }
 
     /**
      * Returns the request HTTP method by taking method spoofing into account.

--- a/src/Request/index.ts
+++ b/src/Request/index.ts
@@ -326,7 +326,7 @@ export class Request extends Macroable implements RequestContract {
    * request.only(['username', 'age'])
    * ```
    */
-  public only<T extends string, U = { [K in T]: any }>(keys: T[]): U {
+  public only<T extends string>(keys: T[]): { [K in T]: any } {
     return lodash.pick(this.requestData, keys)
   }
 


### PR DESCRIPTION
Using an inferred generic permits to destructure the returned value in
any wrong way without TypeScript generating an error, because it infers
the returned object shape based on how it is destructured
