### PR TITLE
fix: request.header return type

### DIFF
--- a/adonis-typings/request.ts
+++ b/adonis-typings/request.ts
@@ -205,7 +205,8 @@ declare module '@ioc:Adonis/Core/Request' {
      * Returns value for a given header key. The default value is
      * used when original value is `undefined`.
      */
-    header(key: string, defaultValue?: any): string | undefined
+    header(key: string): string | undefined
+    header<T>(key: string, defaultValue?: T): string | T
 
     /**
      * Returns the ip address of the user. This method is optimize to fetch


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

When you assign a value to the `defaultValue` param of `request.header`, the return type `undefined` makes no sense. Example:

![image](https://user-images.githubusercontent.com/793157/124174801-14514580-daad-11eb-96b6-d6e8411df9fa.png)

If a `defaultValue` is supplied, the return type should be the value of the generic:

![image](https://user-images.githubusercontent.com/793157/124175263-b3763d00-daad-11eb-83d5-5f6c301ffee5.png)

By applying this generic, we also get valid errors when the types don't match:

![image](https://user-images.githubusercontent.com/793157/124175380-d56fbf80-daad-11eb-8f2f-9ae7db62c797.png)


## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/http-server/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

I want to express my gratitude for creating AdonisJS. I love how strictly typed everything is!
