### PR TITLE
feat(http): allow forceContentNegotiationTo to be a function

### DIFF
--- a/adonis-typings/request.ts
+++ b/adonis-typings/request.ts
@@ -588,7 +588,7 @@ declare module '@ioc:Adonis/Core/Request' {
    * Shape of the request config
    */
   export type RequestConfig = {
-    forceContentNegotiationTo?: string
+    forceContentNegotiationTo?: string | ((ctx: HttpContextContract) => string)
     subdomainOffset: number
     generateRequestId: boolean
     allowMethodSpoofing: boolean

--- a/src/Server/index.ts
+++ b/src/Server/index.ts
@@ -201,12 +201,9 @@ export class Server implements ServerContract {
     /*
      * Reset accept header when `forceContentNegotiationTo` is defined
      */
-    if (this.httpConfig.forceContentNegotiationTo) {
-      if (typeof this.httpConfig.forceContentNegotiationTo === 'function') {
-        ctx.request.request.headers['accept'] = this.httpConfig.forceContentNegotiationTo(ctx)
-      } else {
-        ctx.request.request.headers['accept'] = this.httpConfig.forceContentNegotiationTo
-      }
+    const accept = this.httpConfig.forceContentNegotiationTo
+    if (accept) {
+      req.headers['accept'] = typeof accept === 'function' ? accept(ctx) : accept
     }
 
     if (usingAsyncLocalStorage) {

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -1119,13 +1119,32 @@ test.group('Server | all', (group) => {
     assert.equal(text, 'virk')
   })
 
-  test('set accept header when forceContentNegotiationToJson is true', async (assert) => {
+  test('set accept header when forceContentNegotiationTo is a string', async (assert) => {
     const app = await setupApp()
     const server = new Server(
       app,
       encryption,
       Object.assign({}, serverConfig, {
         forceContentNegotiationTo: 'application/json',
+      })
+    )
+
+    const httpServer = createServer(server.handle.bind(server))
+
+    server.router.get('/', async ({ request, response }) => response.send(request.header('accept')))
+    server.optimize()
+
+    const { text } = await supertest(httpServer).get('/').expect(200)
+    assert.equal(text, 'application/json')
+  })
+
+  test('set accept header when forceContentNegotiationTo is a function', async (assert) => {
+    const app = await setupApp()
+    const server = new Server(
+      app,
+      encryption,
+      Object.assign({}, serverConfig, {
+        forceContentNegotiationTo: () => 'application/json',
       })
     )
 


### PR DESCRIPTION
Hey there! 👋🏻 

This PR allows us to use a function instead of hardcoding a string for the `forceContentNegotiationTo` options.
It can be helpful when you have an application doing SSR & having some API routes that need to be forced to JSON.

Something similar is already done inside the `shield` module.
```ts
exceptRoutes: ({ request }) => request.url().includes('/api'),
```