### PR TITLE
Make findRouteOrFail public

### DIFF
--- a/adonis-typings/route.ts
+++ b/adonis-typings/route.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-declare module '@ioc:Adonis/Core/Route' {
+ declare module '@ioc:Adonis/Core/Route' {
   import { MacroableConstructorContract } from 'macroable'
   import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
   import { ResolvedMiddlewareHandler } from '@ioc:Adonis/Core/Middleware'
@@ -603,6 +603,12 @@ declare module '@ioc:Adonis/Core/Route' {
      * Append query string to the final URI
      */
     qs(qs?: Record<string, any>): this
+
+    /**
+     * Finds the route inside the list of registered routes and
+     * raises exception when unable to
+     */
+    findRouteOrFail(identifier: string)
 
     /**
      * Define required params to resolve the route

--- a/src/Router/LookupStore.ts
+++ b/src/Router/LookupStore.ts
@@ -99,22 +99,6 @@ export class UrlBuilder implements UrlBuilderContract {
   }
 
   /**
-   * Finds the route inside the list of registered routes and
-   * raises exception when unable to
-   */
-  private findRouteOrFail(identifier: string) {
-    const route = this.routes.find(({ name, pattern, handler }) => {
-      return name === identifier || pattern === identifier || handler === identifier
-    })
-
-    if (!route) {
-      throw RouterException.cannotLookupRoute(identifier)
-    }
-
-    return route
-  }
-
-  /**
    * Suffix the query string to the URL
    */
   private suffixQueryString(url: string): string {
@@ -124,6 +108,22 @@ export class UrlBuilder implements UrlBuilderContract {
     }
 
     return url
+  }
+
+  /**
+   * Finds the route inside the list of registered routes and
+   * raises exception when unable to
+   */
+  public findRouteOrFail(identifier: string) {
+    const route = this.routes.find(({ name, pattern, handler }) => {
+      return name === identifier || pattern === identifier || handler === identifier
+    })
+
+    if (!route) {
+      throw RouterException.cannotLookupRoute(identifier)
+    }
+
+    return route
   }
 
   /**


### PR DESCRIPTION
## Proposed changes
The old method lookup(routeIdentifier, forDomain) , was deleted during an old refactoring and we can't look if a route exist.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/http-server/blob/master/.github/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
