### PR TITLE
Route : Add locale and make findRouteOrFail public

### DIFF
--- a/adonis-typings/route.ts
+++ b/adonis-typings/route.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-declare module '@ioc:Adonis/Core/Route' {
+ declare module '@ioc:Adonis/Core/Route' {
   import { MacroableConstructorContract } from 'macroable'
   import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
   import { ResolvedMiddlewareHandler } from '@ioc:Adonis/Core/Middleware'
@@ -603,6 +603,12 @@ declare module '@ioc:Adonis/Core/Route' {
      * Append query string to the final URI
      */
     qs(qs?: Record<string, any>): this
+
+    /**
+     * Finds the route inside the list of registered routes and
+     * raises exception when unable to
+     */
+    findRouteOrFail(identifier: string)
 
     /**
      * Define required params to resolve the route

--- a/adonis-typings/route.ts
+++ b/adonis-typings/route.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
- declare module '@ioc:Adonis/Core/Route' {
+declare module '@ioc:Adonis/Core/Route' {
   import { MacroableConstructorContract } from 'macroable'
   import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
   import { ResolvedMiddlewareHandler } from '@ioc:Adonis/Core/Middleware'
@@ -97,6 +97,11 @@
      * A unique name to lookup routes by name
      */
     name?: string
+
+    /**
+     * The locale of the route
+     */
+    locale?: string
   }
 
   /**
@@ -144,6 +149,7 @@
     methods: string[]
     pattern: string
     name?: string
+    locale?: string
   }
 
   /**
@@ -419,6 +425,7 @@
     qs?: Record<string, any>
     domain?: string
     prefixUrl?: string
+    locale?: string
   } & Record<string, any>
 
   /**
@@ -608,7 +615,7 @@
      * Finds the route inside the list of registered routes and
      * raises exception when unable to
      */
-    findRouteOrFail(identifier: string)
+    findRouteOrFail(identifier: string, locale?: string)
 
     /**
      * Define required params to resolve the route

--- a/src/Router/LookupStore.ts
+++ b/src/Router/LookupStore.ts
@@ -99,22 +99,6 @@ export class UrlBuilder implements UrlBuilderContract {
   }
 
   /**
-   * Finds the route inside the list of registered routes and
-   * raises exception when unable to
-   */
-  private findRouteOrFail(identifier: string) {
-    const route = this.routes.find(({ name, pattern, handler }) => {
-      return name === identifier || pattern === identifier || handler === identifier
-    })
-
-    if (!route) {
-      throw RouterException.cannotLookupRoute(identifier)
-    }
-
-    return route
-  }
-
-  /**
    * Suffix the query string to the URL
    */
   private suffixQueryString(url: string): string {
@@ -124,6 +108,22 @@ export class UrlBuilder implements UrlBuilderContract {
     }
 
     return url
+  }
+
+  /**
+   * Finds the route inside the list of registered routes and
+   * raises exception when unable to
+   */
+  public findRouteOrFail(identifier: string) {
+    const route = this.routes.find(({ name, pattern, handler }) => {
+      return name === identifier || pattern === identifier || handler === identifier
+    })
+
+    if (!route) {
+      throw RouterException.cannotLookupRoute(identifier)
+    }
+
+    return route
   }
 
   /**

--- a/src/Router/LookupStore.ts
+++ b/src/Router/LookupStore.ts
@@ -114,10 +114,20 @@ export class UrlBuilder implements UrlBuilderContract {
    * Finds the route inside the list of registered routes and
    * raises exception when unable to
    */
-  public findRouteOrFail(identifier: string) {
-    const route = this.routes.find(({ name, pattern, handler }) => {
-      return name === identifier || pattern === identifier || handler === identifier
-    })
+  public findRouteOrFail(identifier: string, localeQuery?: string) {
+    let route
+    if (localeQuery) {
+      route = this.routes.find(({ name, pattern, handler, locale }) => {
+        return (
+          (name === identifier || pattern === identifier || handler === identifier) &&
+          locale === localeQuery
+        )
+      })
+    } else {
+      route = this.routes.find(({ name, pattern, handler }) => {
+        return name === identifier || pattern === identifier || handler === identifier
+      })
+    }
 
     if (!route) {
       throw RouterException.cannotLookupRoute(identifier)
@@ -160,8 +170,8 @@ export class UrlBuilder implements UrlBuilderContract {
   /**
    * Generate url for the given route identifier
    */
-  public make(identifier: string) {
-    const route = this.findRouteOrFail(identifier)
+  public make(identifier: string, locale?: string) {
+    const route = this.findRouteOrFail(identifier, locale)
     const url = this.processPattern(route.pattern)
     return this.suffixQueryString(this.baseUrl ? `${this.baseUrl}${url}` : url)
   }

--- a/src/Router/Route.ts
+++ b/src/Router/Route.ts
@@ -84,6 +84,11 @@ export class Route extends Macroable implements RouteContract {
    */
   public name: string
 
+  /**
+   * The locale of the route
+   */
+  public locale: string
+
   constructor(
     private pattern: string,
     private methods: string[],
@@ -224,6 +229,7 @@ export class Route extends Macroable implements RouteContract {
       handler: this.handler,
       methods: this.methods,
       middleware: this.routeMiddleware.flat(),
+      locale: this.locale,
     }
   }
 }

--- a/src/Router/Store.ts
+++ b/src/Router/Store.ts
@@ -132,7 +132,7 @@ export class Store {
     const routeJSON = {} as RouteNode
     lodash.merge(
       routeJSON,
-      lodash.pick(route, ['pattern', 'handler', 'meta', 'middleware', 'name'])
+      lodash.pick(route, ['pattern', 'handler', 'meta', 'middleware', 'name', 'locale'])
     )
 
     /*

--- a/src/Router/index.ts
+++ b/src/Router/index.ts
@@ -393,7 +393,7 @@ export class Router implements RouterContract {
     normalizedOptions.qs && builder.qs(normalizedOptions.qs)
     normalizedOptions.prefixUrl && builder.prefixUrl(normalizedOptions.prefixUrl)
 
-    return builder.make(routeIdentifier)
+    return builder.make(routeIdentifier, options?.locale)
   }
 
   /**


### PR DESCRIPTION
## Proposed changes
The old method lookup(routeIdentifier, forDomain) , was deleted during an old refactoring and we can't look if a route exist.
Also, adding the locale into the route can be helpful.
Example I have UserController.login, and want to use it for english and french, only the last one is taken I think. (using route() in view or with makeUrl etc.)

Here an example : 

```
Route.group(() => {
  Route.get('/', 'MainController.index')
  Route.get('/connexion', 'UsersController.login')
  Route.get('/deconnexion', 'UsersController.logout')
  Route.post('/connexion', 'UsersController.login_form')
  Route.get('/inscription', 'UsersController.register')
  Route.post('/inscription', 'UsersController.store')
  Route.get('/tarification', 'MainController.pricing')
}).prefix('/fr').lang('fr')

```
```
Route.group(() => {
  Route.get('/', 'MainController.index')
  Route.get('/login', 'UsersController.login')
  Route.get('/logout', 'UsersController.logout')
  Route.post('/login', 'UsersController.login_form')
  Route.get('/signup', 'UsersController.register')
  Route.post('/signup', 'UsersController.store')
  Route.get('/pricing', 'MainController.pricing')
}).prefix('/en').lang('en')
```

We have two solution :
### First way, Adding the local into the route : 
**The following code is added manually and is not in the PR, but it can be added somewhere to be permanent**
In AppProvider.ts , inside boot() :
```
    //Mode with locale include into routes
    Routes.RouteGroup.macro('lang', function (lang) {
      this.routes.forEach((route: Route) => {
        //Put the name of the handler into the routes
        //Actually the ressource do that, but we can't with a group, so I created that function
        //If the route name is empty, we can't do .as() , so we init the name
        route.as(route.toJSON().handler.toString())
      });

      //Once the name is init, we can do a .as() , with the locale
      //Ex. Controller.action become locale.Controller.action, example fr.UsersController.login and en.UsersController.login
      this.as(lang)
      return this
    })
  }
```

And in DetectUserLocale I added : 
```
//Override of the route() into view
      ctx.view.share({route : (routeIdentifier: string, params?: any, options?: any) => {
      //Here is if we take that solution, with the locale inside the name, but I prefer the locale as a parameter
        const locale_url = `${ctx.i18n.locale}.${routeIdentifier}`
        let route_exist
        try {
        //At this moment, we CAN'T use .findRouteOrFail() because is private, I make it public in the PR
          Route.builder().findRouteOrFail(locale_url)
          route_exist = true
        } catch (error) {
          route_exist = false
        }
        
        //Return the route with the current locale if exist, else just the route
        return route_exist ? Route.makeUrl(locale_url, params, options) : Route.makeUrl(routeIdentifier, params, options)
      }})
```

### Second method : Add the locale dirrectly into the route
In AppProvider.ts , inside boot() :
Instead of the previous code where the locale was added into the name, we can have this :
```
 Routes.RouteGroup.macro('lang', function (lang) {
     this.routes.forEach((route: Route) => {
       route.locale = lang
     });
     return this
   })
   }
```
With the code in the PR, now we can use this : 
`Route.makeUrl("UsersController.login", {locale: ctx.i18n.locale})`
So the url will be /fr/connexion or /en/login
**Also** : Maybe if a user go dirrectly to /en/login and his default langage is for example french, maybe we want all the /en pages stay in english, so we can change the locale deppending where the user go. If a French user goes in /en/login , I don't want he see /en in the url bar, and all the texts is in french.

**Also :**
If Google Bot crawl /fr/connexion, it will not take the "default locale" from .env, or his Accept-Langage, because Google is always in english. So when he will crawl /fr/connexion, the page will be in French.

You can reply here or dm me on Discord : Reptiluka#4993

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/http-server/blob/master/.github/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

