### PR TITLE
feat(response): add "I'm a Teapot" response helper

### DIFF
--- a/adonis-typings/response.ts
+++ b/adonis-typings/response.ts
@@ -433,6 +433,7 @@ declare module '@ioc:Adonis/Core/Response' {
     serviceUnavailable(body?: any, generateEtag?: boolean): void
     gatewayTimeout(body?: any, generateEtag?: boolean): void
     httpVersionNotSupported(body?: any, generateEtag?: boolean): void
+    imATeapot(body?: any, generateEtag?: boolean): void
   }
 
   /**

--- a/src/Response/index.ts
+++ b/src/Response/index.ts
@@ -1219,4 +1219,9 @@ export class Response extends Macroable implements ResponseContract {
     this.status(505)
     return this.send(body, generateEtag)
   }
+
+  public imATeapot(body?: any, generateEtag?: boolean): void {
+    this.status(418)
+    return this.send(body, generateEtag)
+  }
 }

--- a/test/response.spec.ts
+++ b/test/response.spec.ts
@@ -1108,6 +1108,7 @@ test.group('Response', (group) => {
       'serviceUnavailable',
       'gatewayTimeout',
       'httpVersionNotSupported',
+      'imATeapot',
     ]
 
     methods.forEach((method) => {


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Add a helper method to response in order to return a 418 "I'm a teapot" status code.

https://datatracker.ietf.org/doc/html/rfc2324#section-2.3.2

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/http-server/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments
