### PR TITLE
Allow to create cookies that are not base64 encoded

### DIFF
--- a/adonis-typings/request.ts
+++ b/adonis-typings/request.ts
@@ -570,7 +570,7 @@ declare module '@ioc:Adonis/Core/Request' {
      * Returns value for a given key from unsigned cookies. Optional
      * defaultValue is returned when actual value is undefined.
      */
-    plainCookie(key: string, defaultValue?: any): any
+    plainCookie(key: string, defaultValue?: any, encoded?: boolean): any
 
     /**
      * Returns a boolean telling if a signed url as a valid signature

--- a/adonis-typings/response.ts
+++ b/adonis-typings/response.ts
@@ -352,7 +352,11 @@ declare module '@ioc:Adonis/Core/Response' {
      * Set unsigned cookie as the response header. The inline options overrides
      * all options from the config (means they are not merged)
      */
-    plainCookie(key: string, value: any, options?: Partial<CookieOptions>): this
+    plainCookie(
+      key: string,
+      value: any,
+      options?: Partial<CookieOptions & { encoded: boolean }>
+    ): this
 
     /**
      * Set unsigned cookie as the response header. The inline options overrides

--- a/src/Cookie/Parser/index.ts
+++ b/src/Cookie/Parser/index.ts
@@ -69,7 +69,7 @@ export class CookieParser {
    * you are assuming that the cookie was just encoded at the first
    * place and not signed or encrypted.
    */
-  public decode(key: string): any | null {
+  public decode(key: string, encoded = true): any | null {
     /*
      * Ignore when initial value is not defined or null
      */
@@ -96,7 +96,7 @@ export class CookieParser {
      * Attempt to unpack and cache it for future. The value is only
      * when value it is not null.
      */
-    const parsed = this.client.decode(key, value)
+    const parsed = encoded ? this.client.decode(key, value) : value
     if (parsed !== null) {
       cacheObject[key] = parsed
     }

--- a/src/Cookie/Serializer/index.ts
+++ b/src/Cookie/Serializer/index.ts
@@ -58,8 +58,12 @@ export class CookieSerializer {
    *  serializer.encode('name', 'virk')
    * ```
    */
-  public encode(key: string, value: any, options?: Partial<CookieOptions>): string | null {
-    const packedValue = this.client.encode(key, value)
+  public encode(
+    key: string,
+    value: any,
+    options?: Partial<CookieOptions & { encode: boolean }>
+  ): string | null {
+    const packedValue = !(options?.encode ?? true) ? value : this.client.encode(key, value)
     if (packedValue === null) {
       return null
     }

--- a/src/Request/index.ts
+++ b/src/Request/index.ts
@@ -923,9 +923,9 @@ export class Request extends Macroable implements RequestContract {
    * Returns value for a given key from unsigned cookies. Optional
    * defaultValue is returned when actual value is undefined.
    */
-  public plainCookie(key: string, defaultValue?: string): any {
+  public plainCookie(key: string, defaultValue?: string, encoded?: boolean): any {
     this.initiateCookieParser()
-    return this.cookieParser.decode(key) || defaultValue
+    return this.cookieParser.decode(key, encoded) || defaultValue
   }
 
   /**

--- a/src/Response/index.ts
+++ b/src/Response/index.ts
@@ -951,7 +951,11 @@ export class Response extends Macroable implements ResponseContract {
    * Set unsigned cookie as the response header. The inline options overrides
    * all options from the config (means they are not merged)
    */
-  public plainCookie(key: string, value: any, options?: Partial<CookieOptions>): this {
+  public plainCookie(
+    key: string,
+    value: any,
+    options?: Partial<CookieOptions & { encode: boolean }>
+  ): this {
     options = Object.assign({}, this.config.cookie, options)
 
     const serialized = this.cookieSerializer.encode(key, value, options)

--- a/test/cookie-serializer.spec.ts
+++ b/test/cookie-serializer.spec.ts
@@ -38,6 +38,15 @@ test.group('Cookie | serialize', () => {
     assert.equal(base64.urlDecode(serialized!.split('=')[1]), '{"message":"virk"}')
   })
 
+  test(`serialize and don't encode cookie`, ({ assert }) => {
+    const serializer = new CookieSerializer(encryption)
+    const serialized = serializer.encode('username', 'virk', { encode: false })
+
+    assert.isNotNull(serialized)
+    assert.equal(serialized!.split('=')[0], 'username')
+    assert.equal(serialized!.split('=')[1], 'virk')
+  })
+
   test('set cookie domain', ({ assert }) => {
     const serializer = new CookieSerializer(encryption)
     const serialized = serializer.encode('username', 'virk', { domain: 'adonisjs.com' })

--- a/test/request.spec.ts
+++ b/test/request.spec.ts
@@ -981,6 +981,22 @@ test.group('Request', () => {
     })
   })
 
+  test('get value for a single not encoded cookie', async ({ assert }) => {
+    const config = requestConfig
+
+    const server = createServer((req, res) => {
+      const request = new Request(req, res, encryption, config)
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ name: request.plainCookie('name', undefined, false) }))
+    })
+
+    const cookies = serializer.encode('name', 'virk', { encode: false })!
+    const { body } = await supertest(server).get('/').set('cookie', cookies)
+    assert.deepEqual(body, {
+      name: 'virk',
+    })
+  })
+
   test('get value for a single encrypted', async ({ assert }) => {
     const config = requestConfig
 


### PR DESCRIPTION
Hey! 👋🏻 

This PR adds the possibility to create `plainCookie` without encoding them to base64 before saving them.

```ts
response.plainCookie('name', 'romain', { encode: false })
```

This can be useful when you are creating the cookie for third-party services that do not expect base64 cookies.