### PR TITLE
Feat/serialize set

### DIFF
--- a/src/Response/index.ts
+++ b/src/Response/index.ts
@@ -179,6 +179,13 @@ export class Response extends Macroable implements ResponseContract {
       return 'regexp'
     }
 
+    /**
+     * Set instance
+     */
+    if (content instanceof Set) {
+      return 'set'
+    }
+
     const dataType = typeof content
     if (
       dataType === 'number' ||
@@ -261,6 +268,8 @@ export class Response extends Macroable implements ResponseContract {
      */
     if (dataType === 'object') {
       content = safeStringify(content)
+    } else if (dataType === 'set') {
+      content = safeStringify(Array.from(content))
     } else if (
       dataType === 'number' ||
       dataType === 'boolean' ||
@@ -359,6 +368,7 @@ export class Response extends Macroable implements ResponseContract {
         case 'buffer':
           this.safeHeader('Content-Type', 'application/octet-stream; charset=utf-8')
           break
+        case 'set':
         case 'object':
           this.safeHeader('Content-Type', 'application/json; charset=utf-8')
           break

--- a/test/response.spec.ts
+++ b/test/response.spec.ts
@@ -800,6 +800,20 @@ test.group('Response', (group) => {
     assert.deepEqual(body, { username: 'virk' })
   })
 
+  test('convert Set to JSON representation', async ({ assert }) => {
+    const data = new Set()
+    data.add('virk')
+
+    const server = createServer((req, res) => {
+      const response = new Response(req, res, encryption, responseConfig, router)
+      response.send(data)
+      response.finish()
+    })
+
+    const { body } = await supertest(server).get('/')
+    assert.deepEqual(body, ['virk'])
+  })
+
   test('send response as 200 when request method is HEAD and cache is not fresh', async ({
     assert,
   }) => {


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds a serializing step if we are providing a `Set` as a response.

```ts
Route.get('/', () => {
  const data = new Set()
  data.add('foo')

  return data
})
```

The code above was returning an empty object before, now it returns the expected value: `['foo']`.