### PR TITLE
fix: add missing @types/node package

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/fs-extra": "^11.0.1",
     "@types/http-status-codes": "^1.2.0",
     "@types/mime-types": "^2.1.1",
+    "@types/node": "^18.14.6",
     "@types/on-finished": "^2.3.1",
     "@types/pem": "^1.9.6",
     "@types/proxy-addr": "^2.0.0",


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds the missing `@types/node` package we require.