### PR TITLE
feat(encryption): use new encryption module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,14 @@ coverage
 .nyc_output
 .idea
 .vscode/
+.yalc
 *.sublime-project
 *.sublime-workspace
 *.log
 build
 dist
 yarn.lock
+yalc.lock
 shrinkwrap.yaml
 package-lock.json
 test/__app

--- a/benchmarks/adonisjs.ts
+++ b/benchmarks/adonisjs.ts
@@ -9,7 +9,8 @@
 
 import { createServer } from 'node:http'
 import { Emitter } from '@adonisjs/events'
-import { Encryption } from '@adonisjs/encryption'
+import { EncryptionManager } from '@adonisjs/encryption'
+import { Legacy } from '@adonisjs/encryption/drivers/legacy'
 import { Application } from '@adonisjs/application'
 
 import { defineConfig } from '../index.js'
@@ -22,7 +23,12 @@ const app = new Application(new URL('./', import.meta.url), {
 })
 await app.init()
 
-const encryption = new Encryption({ secret: 'averylongrandom32charslongsecret' })
+const encryption = new EncryptionManager({
+  default: 'legacy',
+  list: {
+    legacy: () => new Legacy({ key: 'averylongrandom32charslongsecret' }),
+  },
+})
 
 const server = new Server(
   app,

--- a/factories/request.ts
+++ b/factories/request.ts
@@ -9,9 +9,9 @@
 
 import { Socket } from 'node:net'
 import proxyAddr from 'proxy-addr'
-import type { Encryption } from '@adonisjs/encryption'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 import { IncomingMessage, ServerResponse } from 'node:http'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import type { Encryption } from '@adonisjs/encryption'
 
 import { Request } from '../src/request.js'
 import { RequestConfig } from '../src/types/request.js'
@@ -74,7 +74,7 @@ export class RequestFactory {
    * signed URLs
    */
   #createEncryption() {
-    return this.#parameters.encryption || new EncryptionFactory().create()
+    return this.#parameters.encryption || new EncryptionManagerFactory().create().use()
   }
 
   /**

--- a/factories/response.ts
+++ b/factories/response.ts
@@ -10,7 +10,7 @@
 import { Socket } from 'node:net'
 import type { Encryption } from '@adonisjs/encryption'
 import { IncomingMessage, ServerResponse } from 'node:http'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { RouterFactory } from './router.js'
 import { Response } from '../src/response.js'
@@ -77,7 +77,7 @@ export class ResponseFactory {
    * signed URLs
    */
   #createEncryption() {
-    return this.#parameters.encryption || new EncryptionFactory().create()
+    return this.#parameters.encryption || new EncryptionManagerFactory().create().use()
   }
 
   /**

--- a/factories/router.ts
+++ b/factories/router.ts
@@ -10,7 +10,7 @@
 import type { Encryption } from '@adonisjs/encryption'
 import type { Application } from '@adonisjs/application'
 import { AppFactory } from '@adonisjs/application/factories'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { Router } from '../src/router/main.js'
 import { QsParserFactory } from './qs_parser_factory.js'
@@ -41,7 +41,7 @@ export class RouterFactory {
    * signed URLs
    */
   #createEncryption() {
-    return this.#parameters.encryption || new EncryptionFactory().create()
+    return this.#parameters.encryption || new EncryptionManagerFactory().create().use()
   }
 
   /**

--- a/factories/server_factory.ts
+++ b/factories/server_factory.ts
@@ -9,10 +9,10 @@
 
 import { Logger } from '@adonisjs/logger'
 import { Emitter } from '@adonisjs/events'
-import type { Encryption } from '@adonisjs/encryption'
+import type { EncryptionManager } from '@adonisjs/encryption'
 import type { Application } from '@adonisjs/application'
 import { AppFactory } from '@adonisjs/application/factories'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { Server } from '../src/server/main.js'
 import { defineConfig } from '../src/define_config.js'
@@ -21,7 +21,7 @@ import type { ServerConfig } from '../src/types/server.js'
 type FactoryParameters = {
   app: Application<any>
   logger: Logger
-  encryption: Encryption
+  encryption: EncryptionManager<any>
   emitter: Emitter<any>
   config: Partial<ServerConfig>
 }
@@ -68,7 +68,7 @@ export class ServerFactory {
    * signed URLs
    */
   #createEncryption() {
-    return this.#parameters.encryption || new EncryptionFactory().create()
+    return this.#parameters.encryption || new EncryptionManagerFactory().create()
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "devDependencies": {
     "@adonisjs/application": "^7.1.2-9",
-    "@adonisjs/encryption": "^5.1.2-2",
+    "@adonisjs/encryption": "file:.yalc/@adonisjs/encryption",
     "@adonisjs/eslint-config": "^1.1.8",
     "@adonisjs/events": "^8.4.9-4",
     "@adonisjs/fold": "^9.9.3-7",
@@ -98,6 +98,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
+    "@adonisjs/core": "file:.yalc/@adonisjs/core",
     "@paralleldrive/cuid2": "^2.2.1",
     "@poppinss/macroable": "^1.0.0-7",
     "@poppinss/matchit": "^3.1.2",

--- a/src/cookies/drivers/signed.ts
+++ b/src/cookies/drivers/signed.ts
@@ -17,7 +17,7 @@ export function pack(key: string, value: any, encryption: Encryption): null | st
   if (value === undefined || value === null) {
     return null
   }
-  return `s:${encryption.verifier.sign(value, undefined, key)}`
+  return `s:${encryption.getMessageVerifier().sign(value, undefined, key)}`
 }
 
 /**
@@ -38,5 +38,5 @@ export function unpack(key: string, signedValue: string, encryption: Encryption)
     return null
   }
 
-  return encryption.verifier.unsign(value, key)
+  return encryption.getMessageVerifier().unsign(value, key)
 }

--- a/src/define_config.ts
+++ b/src/define_config.ts
@@ -16,6 +16,10 @@ import type { ServerConfig } from './types/server.js'
  */
 export function defineConfig(config: Partial<ServerConfig>): ServerConfig {
   const normalizedConfig = {
+    encrypters: {
+      cookie: 'legacy',
+      signedRoute: 'legacy',
+    },
     allowMethodSpoofing: false,
     trustProxy: proxyAddr.compile('loopback'),
     subdomainOffset: 2,

--- a/src/request.ts
+++ b/src/request.ts
@@ -19,7 +19,7 @@ import lodash from '@poppinss/utils/lodash'
 import { createId } from '@paralleldrive/cuid2'
 import { parse, UrlWithStringQuery } from 'node:url'
 import type { Encryption } from '@adonisjs/encryption'
-import { ServerResponse, IncomingMessage, IncomingHttpHeaders } from 'node:http'
+import type { ServerResponse, IncomingMessage, IncomingHttpHeaders } from 'node:http'
 
 import type { Qs } from './qs.js'
 import { trustProxy } from './helpers.js'
@@ -941,7 +941,7 @@ export class Request extends Macroable {
     /*
      * Return false when signature fails
      */
-    const signedUrl = this.#encryption.verifier.unsign(signature, purpose)
+    const signedUrl = this.#encryption.getMessageVerifier().unsign(signature, purpose)
     if (!signedUrl) {
       return false
     }

--- a/src/router/lookup_store/url_builder.ts
+++ b/src/router/lookup_store/url_builder.ts
@@ -13,6 +13,7 @@ import type { Encryption } from '@adonisjs/encryption'
 import type { Qs } from '../../qs.js'
 import { parseRoutePattern } from '../parser.js'
 import type { RouteFinder } from './route_finder.js'
+import { EncryptersList } from '@adonisjs/core/types'
 
 /**
  * URL builder class is used to create URIs for pre-registered
@@ -220,7 +221,10 @@ export class UrlBuilder {
    * route name, controller.method name or the route pattern
    * itself.
    */
-  makeSigned(identifier: string, options?: { expiresIn?: string | number; purpose?: string }) {
+  makeSigned(
+    identifier: string,
+    options?: { encrypter?: EncryptersList; expiresIn?: string | number; purpose?: string }
+  ) {
     let url: string
 
     if (this.#shouldPerformLookup) {
@@ -238,11 +242,9 @@ export class UrlBuilder {
      * on their 2 different domains, but we ignore that case for now and can consider
      * it later (when someone asks for it)
      */
-    const signature = this.#encryption.verifier.sign(
-      this.#suffixQueryString(url, this.#qs),
-      options?.expiresIn,
-      options?.purpose
-    )
+    const signature = this.#encryption
+      .getMessageVerifier()
+      .sign(this.#suffixQueryString(url, this.#qs), options?.expiresIn, options?.purpose)
 
     const qs = Object.assign({}, this.#qs, { signature })
     return this.#suffixQueryString(this.#prefixBaseUrl(url), qs)

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -148,11 +148,7 @@ export class Server {
     this.#logger = logger
     this.#encryption = encryption
     this.#qsParser = new Qs(this.#config.qs)
-    this.#router = new Router(
-      this.#app,
-      this.#encryption.use(config.encrypters.signedRoute),
-      this.#qsParser
-    )
+    this.#router = new Router(this.#app, this.#encryption.use(), this.#qsParser)
     this.#createAsyncLocalStore()
 
     debug('server config: %O', this.#config)
@@ -305,13 +301,7 @@ export class Server {
    * Creates an instance of the [[Request]] class
    */
   createRequest(req: IncomingMessage, res: ServerResponse) {
-    return new Request(
-      req,
-      res,
-      this.#encryption.use(this.#config.encrypters.cookie),
-      this.#config,
-      this.#qsParser
-    )
+    return new Request(req, res, this.#encryption.use(), this.#config, this.#qsParser)
   }
 
   /**
@@ -321,7 +311,7 @@ export class Server {
     return new Response(
       req,
       res,
-      this.#encryption.use(this.#config.encrypters.cookie),
+      this.#encryption.use(),
       this.#config,
       this.#router,
       this.#qsParser

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -14,7 +14,6 @@ import type { QSParserConfig } from './qs.js'
 import type { RequestConfig } from './request.js'
 import type { ResponseConfig } from './response.js'
 import type { HttpContext } from '../http_context/main.js'
-import { EncryptersList } from '@adonisjs/core/types'
 
 /**
  * Normalized HTTP error used by the exception
@@ -90,13 +89,4 @@ export type ServerConfig = RequestConfig &
      * Config for query string parser
      */
     qs: QSParserConfig
-
-    /**
-     * The encrypter to be used for signing cookies and
-     * routes.
-     */
-    encrypters: {
-      cookie: EncryptersList
-      signedRoute: EncryptersList
-    }
   }

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -14,6 +14,7 @@ import type { QSParserConfig } from './qs.js'
 import type { RequestConfig } from './request.js'
 import type { ResponseConfig } from './response.js'
 import type { HttpContext } from '../http_context/main.js'
+import { EncryptersList } from '@adonisjs/core/types'
 
 /**
  * Normalized HTTP error used by the exception
@@ -89,4 +90,13 @@ export type ServerConfig = RequestConfig &
      * Config for query string parser
      */
     qs: QSParserConfig
+
+    /**
+     * The encrypter to be used for signing cookies and
+     * routes.
+     */
+    encrypters: {
+      cookie: EncryptersList
+      signedRoute: EncryptersList
+    }
   }

--- a/tests/cookies/client.spec.ts
+++ b/tests/cookies/client.spec.ts
@@ -8,11 +8,11 @@
  */
 
 import { test } from '@japa/runner'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { CookieClient } from '../../src/cookies/client.js'
 
-const encryption = new EncryptionFactory().create()
+const encryption = new EncryptionManagerFactory().create().use()
 
 test.group('Cookie Client', () => {
   test('sign cookie', async ({ assert }) => {

--- a/tests/cookies/drivers/encrypted.spec.ts
+++ b/tests/cookies/drivers/encrypted.spec.ts
@@ -17,10 +17,10 @@
  */
 
 import { test } from '@japa/runner'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 import { pack, unpack, canUnpack } from '../../../src/cookies/drivers/encrypted.js'
 
-const encryption = new EncryptionFactory().create()
+const encryption = new EncryptionManagerFactory().create().use()
 
 test.group('Cookie | driver | encrypted', () => {
   test('encrypt value', ({ assert }) => {

--- a/tests/cookies/drivers/signed.spec.ts
+++ b/tests/cookies/drivers/signed.spec.ts
@@ -17,10 +17,10 @@
  */
 
 import { test } from '@japa/runner'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 import { pack, unpack, canUnpack } from '../../../src/cookies/drivers/signed.js'
 
-const encryption = new EncryptionFactory().create()
+const encryption = new EncryptionManagerFactory().create().use()
 
 test.group('Cookie | driver | signed', () => {
   test('sign value', ({ assert }) => {

--- a/tests/cookies/parser.spec.ts
+++ b/tests/cookies/parser.spec.ts
@@ -8,12 +8,12 @@
  */
 
 import { test } from '@japa/runner'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { CookieParser } from '../../src/cookies/parser.js'
 import { CookieSerializer } from '../../src/cookies/serializer.js'
 
-const encryption = new EncryptionFactory().create()
+const encryption = new EncryptionManagerFactory().create().use()
 const serializer = new CookieSerializer(encryption)
 
 test.group('Cookie | parse', () => {

--- a/tests/cookies/serializer.spec.ts
+++ b/tests/cookies/serializer.spec.ts
@@ -10,11 +10,11 @@
 import { test } from '@japa/runner'
 import { setTimeout } from 'node:timers/promises'
 import { base64, MessageBuilder } from '@poppinss/utils'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { CookieSerializer } from '../../src/cookies/serializer.js'
 
-const encryption = new EncryptionFactory().create()
+const encryption = new EncryptionManagerFactory().create().use()
 
 test.group('Cookie | serialize', () => {
   test('serialize and sign cookie', ({ assert }) => {

--- a/tests/redirect.spec.ts
+++ b/tests/redirect.spec.ts
@@ -10,7 +10,7 @@
 import supertest from 'supertest'
 import { test } from '@japa/runner'
 import { AppFactory } from '@adonisjs/application/factories'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { RouterFactory } from '../factories/router.js'
 import { httpServer } from '../factories/http_server.js'
@@ -19,7 +19,7 @@ import { ResponseFactory } from '../factories/response.js'
 const BASE_URL = new URL('./app/', import.meta.url)
 
 const app = new AppFactory().create(BASE_URL, () => {})
-const encryption = new EncryptionFactory().create()
+const encryption = new EncryptionManagerFactory().create().use()
 const router = new RouterFactory().merge({ app, encryption }).create()
 
 test.group('Redirect', () => {

--- a/tests/request.spec.ts
+++ b/tests/request.spec.ts
@@ -12,7 +12,7 @@ import supertest from 'supertest'
 import { test } from '@japa/runner'
 import Middleware from '@poppinss/middleware'
 import { createServer as httpsServer } from 'node:https'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { RequestFactory } from '../factories/request.js'
 import { httpServer } from '../factories/http_server.js'
@@ -21,7 +21,7 @@ import { HttpContextFactory } from '../factories/http_context.js'
 import { QsParserFactory } from '../factories/qs_parser_factory.js'
 import { UrlBuilder } from '../src/router/lookup_store/url_builder.js'
 
-const encryption = new EncryptionFactory().create()
+const encryption = new EncryptionManagerFactory().create().use()
 const serializer = new CookieSerializer(encryption)
 
 test.group('Request', () => {

--- a/tests/response.spec.ts
+++ b/tests/response.spec.ts
@@ -17,7 +17,7 @@ import { Readable } from 'node:stream'
 import { fileURLToPath } from 'node:url'
 import { AppFactory } from '@adonisjs/application/factories'
 import { createWriteStream, createReadStream } from 'node:fs'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { Response } from '../src/response.js'
 import { RouterFactory } from '../factories/router.js'
@@ -28,7 +28,7 @@ import { ResponseFactory } from '../factories/response.js'
 const BASE_URL = new URL('./app/', import.meta.url)
 const BASE_PATH = fileURLToPath(BASE_URL)
 
-const encryption = new EncryptionFactory().create()
+const encryption = new EncryptionManagerFactory().create().use()
 const app = new AppFactory().create(BASE_URL, () => {})
 const router = new RouterFactory().merge({ app, encryption }).create()
 

--- a/tests/router/lookup_store.spec.ts
+++ b/tests/router/lookup_store.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from '@japa/runner'
 import { AppFactory } from '@adonisjs/application/factories'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { Route } from '../../src/router/route.js'
 import { LookupStore } from '../../src/router/lookup_store/main.js'
@@ -20,7 +20,7 @@ const BASE_URL = new URL('./app/', import.meta.url)
 test.group('Lookup store | find', () => {
   test('find a route by route pattern', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {
@@ -43,7 +43,7 @@ test.group('Lookup store | find', () => {
 
   test('find a route by route name', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {
@@ -67,7 +67,7 @@ test.group('Lookup store | find', () => {
 
   test('find a route by route controller name', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {
@@ -89,7 +89,7 @@ test.group('Lookup store | find', () => {
   })
 
   test('return null when unable to find route', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.isNull(lookupStore.find('/users/:id'))
@@ -97,7 +97,7 @@ test.group('Lookup store | find', () => {
 
   test('do not match route handler name when it is defined as function', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {
@@ -116,7 +116,7 @@ test.group('Lookup store | find', () => {
 test.group('Lookup store | findByOrFail', () => {
   test('find a route by route pattern', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {
@@ -139,7 +139,7 @@ test.group('Lookup store | findByOrFail', () => {
 
   test('find a route by route name', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {
@@ -163,7 +163,7 @@ test.group('Lookup store | findByOrFail', () => {
 
   test('find a route by route controller name', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {
@@ -185,7 +185,7 @@ test.group('Lookup store | findByOrFail', () => {
   })
 
   test('raise error when unable to lookup route', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.throws(() => lookupStore.findOrFail('/users/:id'), 'Cannot lookup route "/users/:id"')
@@ -195,7 +195,7 @@ test.group('Lookup store | findByOrFail', () => {
 test.group('Lookup store | has', () => {
   test('check if a route exists', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {

--- a/tests/router/router.spec.ts
+++ b/tests/router/router.spec.ts
@@ -9,7 +9,7 @@
 
 import { parse } from 'qs'
 import { test } from '@japa/runner'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { RouterFactory } from '../../factories/router.js'
 
@@ -876,7 +876,7 @@ test.group('Router | Make url', () => {
 
 test.group('Make signed url', () => {
   test('make signed url to a given route', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const router = new RouterFactory().merge({ encryption }).create()
 
     router.get('posts/:id', async function handler() {})
@@ -884,11 +884,11 @@ test.group('Make signed url', () => {
 
     const url = router.makeSignedUrl('/posts/:id', { id: 1 })!
     const qs = parse(url.split('?')[1])
-    assert.equal(encryption.verifier.unsign(qs.signature as string), '/posts/1')
+    assert.equal(encryption.getMessageVerifier().unsign(qs.signature as string), '/posts/1')
   })
 
   test("make signed url to a given route by it's name", ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const router = new RouterFactory().merge({ encryption }).create()
 
     router.get('posts/:id', async function handler() {}).as('showPost')
@@ -896,11 +896,11 @@ test.group('Make signed url', () => {
 
     const url = router.makeSignedUrl('showPost', { id: 1 })!
     const qs = parse(url.split('?')[1])
-    assert.equal(encryption.verifier.unsign(qs.signature as string), '/posts/1')
+    assert.equal(encryption.getMessageVerifier().unsign(qs.signature as string), '/posts/1')
   })
 
   test("make signed url to a given route by it's controller method", ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const router = new RouterFactory().merge({ encryption }).create()
 
     router.get('posts/:id', '#controllers/posts.index').as('showPost')
@@ -908,11 +908,11 @@ test.group('Make signed url', () => {
 
     const url = router.makeSignedUrl('#controllers/posts.index', { id: 1 })!
     const qs = parse(url.split('?')[1])
-    assert.equal(encryption.verifier.unsign(qs.signature as string), '/posts/1')
+    assert.equal(encryption.getMessageVerifier().unsign(qs.signature as string), '/posts/1')
   })
 
   test('make url for a specific domain', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const router = new RouterFactory().merge({ encryption }).create()
 
     router.get('posts/:id', '#controllers/posts.index').as('showPost')
@@ -931,11 +931,11 @@ test.group('Make signed url', () => {
       }
     )!
     const qs = parse(url.split('?')[1])
-    assert.equal(encryption.verifier.unsign(qs.signature as string), '/articles/1')
+    assert.equal(encryption.getMessageVerifier().unsign(qs.signature as string), '/articles/1')
   })
 
   test('make signed url with expiry', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const router = new RouterFactory().merge({ encryption }).create()
 
     router.get('posts/:id', 'PostsController.index')
@@ -944,11 +944,11 @@ test.group('Make signed url', () => {
     const url = router.makeSignedUrl('PostsController.index', { id: 1, expiresIn: '1m' })!
     const qs = parse(url.split('?')[1])
 
-    assert.equal(encryption.verifier.unsign(qs.signature as string), '/posts/1')
+    assert.equal(encryption.getMessageVerifier().unsign(qs.signature as string), '/posts/1')
   })
 
   test('make signed url with custom query string', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const router = new RouterFactory().merge({ encryption }).create()
 
     router.get('posts/:id', 'PostsController.index')
@@ -959,7 +959,7 @@ test.group('Make signed url', () => {
     })!
     const qs = parse(url.split('?')[1])
 
-    assert.equal(encryption.verifier.unsign(qs.signature as string), '/posts/1?page=1')
+    assert.equal(encryption.getMessageVerifier().unsign(qs.signature as string), '/posts/1?page=1')
     assert.equal(Number(qs.page), 1)
   })
 

--- a/tests/router/url_builder.spec.ts
+++ b/tests/router/url_builder.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from '@japa/runner'
 import { AppFactory } from '@adonisjs/application/factories'
-import { EncryptionFactory } from '@adonisjs/encryption/factories'
+import { EncryptionManagerFactory } from '@adonisjs/encryption/factories'
 
 import { Route } from '../../src/router/route.js'
 import { RequestFactory } from '../../factories/request.js'
@@ -21,7 +21,7 @@ const BASE_URL = new URL('./app/', import.meta.url)
 test.group('URL builder', () => {
   test('create url for a route', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {
@@ -37,7 +37,7 @@ test.group('URL builder', () => {
 
   test('create url for a route by its name', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {
@@ -54,7 +54,7 @@ test.group('URL builder', () => {
 
   test('create url for a route by the handler name', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {
@@ -69,7 +69,7 @@ test.group('URL builder', () => {
   })
 
   test('raise error when unable to lookup route', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.throws(
@@ -79,7 +79,7 @@ test.group('URL builder', () => {
   })
 
   test('create url without performing route lookup', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.equal(
@@ -89,7 +89,7 @@ test.group('URL builder', () => {
   })
 
   test('define params as an object', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.equal(
@@ -99,7 +99,7 @@ test.group('URL builder', () => {
   })
 
   test('do not overwrite existing params when undefined params are shared', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.equal(
@@ -109,7 +109,7 @@ test.group('URL builder', () => {
   })
 
   test('raise error when one or params are missing', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.throws(
@@ -119,14 +119,14 @@ test.group('URL builder', () => {
   })
 
   test('allow missing params when param is optional', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.equal(lookupStore.builder().disableRouteLookup().make('/users/:id?'), '/users')
   })
 
   test('make route with wildcard params', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.equal(
@@ -136,7 +136,7 @@ test.group('URL builder', () => {
   })
 
   test('define wildcard param as an object', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.equal(
@@ -152,7 +152,7 @@ test.group('URL builder', () => {
   })
 
   test('raise error when wildcard params are missing', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.throws(
@@ -162,7 +162,7 @@ test.group('URL builder', () => {
   })
 
   test('prefix url', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.equal(
@@ -172,7 +172,7 @@ test.group('URL builder', () => {
   })
 
   test('define query string with arrays', ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     assert.equal(
@@ -189,7 +189,7 @@ test.group('URL builder', () => {
   })
 
   test('create and verify signed URLs', async ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const signedUrl = lookupStore.builder().disableRouteLookup().makeSigned('/users')
@@ -205,7 +205,7 @@ test.group('URL builder', () => {
   })
 
   test('create and verify signed URLs with query string', async ({ assert }) => {
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const signedUrl = lookupStore
@@ -229,7 +229,7 @@ test.group('URL builder', () => {
 
   test('build route with params and extension', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
-    const encryption = new EncryptionFactory().create()
+    const encryption = new EncryptionManagerFactory().create().use()
     const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
 
     const route = new Route(app, [], {


### PR DESCRIPTION
Hey! 👋🏻 

This PR moves any reference to the encryption to the new driver-based system.

You can now specify which encryptor you want to use to sign route or encrypt cookies.

```ts
defineConfig({
  encrypters: {
    signedRoute: 'legacy',
    cookie: 'legacy',
  }
})
```

Related:
- https://github.com/adonisjs/road-to-v6/issues/18
- https://github.com/adonisjs/core/pull/4207