### PR TITLE
fix: clearing slash prefixes before adding uriSegment within url builder's processPattern

### DIFF
--- a/src/router/lookup_store/url_builder.ts
+++ b/src/router/lookup_store/url_builder.ts
@@ -110,7 +110,8 @@ export class UrlBuilder {
        * we must break out from the loop
        */
       if (token.type === 0) {
-        uriSegments.push(`${token.val}${token.end}`)
+        const value = token.val.startsWith('/') ? token.val.substring(1) : token.val
+        uriSegments.push(`${value}${token.end}`)
       } else if (token.type === 2) {
         const values: string[] = paramsArray ? paramsArray.slice(paramsIndex) : paramsObject['*']
         this.#ensureHasWildCardValues(pattern, values)

--- a/tests/router/url_builder.spec.ts
+++ b/tests/router/url_builder.spec.ts
@@ -52,6 +52,23 @@ test.group('URL builder', () => {
     assert.equal(lookupStore.builder().params([1]).make('users.show'), '/users/1')
   })
 
+  test('create url for a route by its name for the home path', ({ assert }) => {
+    const app = new AppFactory().create(BASE_URL, () => {})
+    const encryption = new EncryptionFactory().create()
+    const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
+
+    const route = new Route(app, [], {
+      pattern: '/',
+      globalMatchers: {},
+      handler: () => {},
+      methods: ['GET'],
+    })
+    route.as('home')
+
+    lookupStore.register(route.toJSON())
+    assert.equal(lookupStore.builder().make('home'), '/')
+  })
+
   test('create url for a route by the handler name', ({ assert }) => {
     const app = new AppFactory().create(BASE_URL, () => {})
     const encryption = new EncryptionFactory().create()
@@ -66,6 +83,22 @@ test.group('URL builder', () => {
 
     lookupStore.register(route.toJSON())
     assert.equal(lookupStore.builder().params([1]).make('#controllers/posts'), '/users/1')
+  })
+
+  test('create url for a route by the handler name for the home path', ({ assert }) => {
+    const app = new AppFactory().create(BASE_URL, () => {})
+    const encryption = new EncryptionFactory().create()
+    const lookupStore = new LookupStore(encryption, new QsParserFactory().create())
+
+    const route = new Route(app, [], {
+      pattern: '/',
+      globalMatchers: {},
+      handler: '#controllers/home',
+      methods: ['GET'],
+    })
+
+    lookupStore.register(route.toJSON())
+    assert.equal(lookupStore.builder().params([1]).make('#controllers/home'), '/')
   })
 
   test('raise error when unable to lookup route', ({ assert }) => {


### PR DESCRIPTION
## Proposed changes

Fixes [v6 issue 48](https://github.com/adonisjs/road-to-v6/issues/48), by stripping slashes prior to adding `uriSegment` within `proccessPattern`.

Changes this:
```ts
if (token.type === 0) {
  uriSegments.push(`${token.val}${token.end}`)
}
```
To this:
```ts
if (token.type === 0) {
  const value = token.val.startsWith('/') ? token.val.substring(1) : token.val
  uriSegments.push(`${value}${token.end}`)
}
```

Added two new tests as well to cover this noted issue within `tests/router/url_builder.spec.ts`:
- create url for a route by its name for the home path
- create url for a route by the handler name for the home path


## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/http-server/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate) 

## Further comments

Doesn't look like `npm commit` exists yet in the `next` branch, so I went ahead and just used `git commit`. If you need anything changed, just let me know 😊
