### PR TITLE
look first for route node that matches the url

### DIFF
--- a/src/router/store.ts
+++ b/src/router/store.ts
@@ -218,9 +218,7 @@ export class RoutesStore {
      * First look if we have any route node for the given url.
      * In case the `url` is the same as the `pattern` return the `MatchedRoute`.
      */
-    const routeNode = Object.values(matchedMethod.routes).find((route) => {
-      return route.pattern.toLowerCase() === url.toLowerCase()
-    })
+    const routeNode = matchedMethod.routes[url]
     if (routeNode) {
       return {
         route: routeNode,

--- a/src/router/store.ts
+++ b/src/router/store.ts
@@ -214,6 +214,20 @@ export class RoutesStore {
       return null
     }
 
+    /**
+     * First look if we have any route node for the given url.
+     * In case the `url` is the same as the `pattern` return the `MatchedRoute`.
+     */
+    const routeNode = matchedMethod.routes[url]
+    if (routeNode) {
+      return {
+        route: routeNode,
+        routeKey: matchedMethod.routeKeys[routeNode.pattern],
+        params: {},
+        subdomains: domain?.hostname ? matchit.exec(domain.hostname, domain.tokens) : {},
+      }
+    }
+
     /*
      * Next, match route for the given url inside the tokens list for the
      * matchedMethod

--- a/src/router/store.ts
+++ b/src/router/store.ts
@@ -218,7 +218,9 @@ export class RoutesStore {
      * First look if we have any route node for the given url.
      * In case the `url` is the same as the `pattern` return the `MatchedRoute`.
      */
-    const routeNode = matchedMethod.routes[url]
+    const routeNode = Object.values(matchedMethod.routes).find((route) => {
+      return route.pattern.toLowerCase() === url.toLowerCase()
+    })
     if (routeNode) {
       return {
         route: routeNode,

--- a/tests/router/store.spec.ts
+++ b/tests/router/store.spec.ts
@@ -627,21 +627,6 @@ test.group('Store | match', () => {
       routeKey: 'GET-/user',
     })
 
-    assert.deepEqual(store.match('/USER', 'GET'), {
-      route: {
-        pattern: '/user',
-        handler,
-        execute,
-        middleware: new Middleware<any>(),
-        meta: {
-          params: [],
-        },
-      },
-      params: {},
-      subdomains: {},
-      routeKey: 'GET-/user',
-    })
-
     assert.deepEqual(store.match('/12345', 'GET'), {
       route: {
         pattern: '/:id',

--- a/tests/router/store.spec.ts
+++ b/tests/router/store.spec.ts
@@ -585,6 +585,66 @@ test.group('Store | match', () => {
     })
   })
 
+  test('find route for a given url - pattern priority over route with params', ({ assert }) => {
+    async function handler() {}
+
+    const store = new RoutesStore()
+
+    store.add({
+      pattern: '/:id',
+      handler,
+      matchers: {},
+      meta: {},
+      execute,
+      middleware: new Middleware<any>(),
+      methods: ['GET'],
+      domain: 'root',
+    })
+
+    store.add({
+      pattern: '/123',
+      handler,
+      matchers: {},
+      meta: {},
+      execute,
+      middleware: new Middleware<any>(),
+      methods: ['GET'],
+      domain: 'root',
+    })
+
+    assert.deepEqual(store.match('/123', 'GET'), {
+      route: {
+        pattern: '/123',
+        handler,
+        execute,
+        middleware: new Middleware<any>(),
+        meta: {
+          params: [],
+        },
+      },
+      params: {},
+      subdomains: {},
+      routeKey: 'GET-/123',
+    })
+
+    assert.deepEqual(store.match('/12345', 'GET'), {
+      route: {
+        pattern: '/:id',
+        handler,
+        execute,
+        middleware: new Middleware<any>(),
+        meta: {
+          params: ['id'],
+        },
+      },
+      params: {
+        id: '12345',
+      },
+      subdomains: {},
+      routeKey: 'GET-/:id',
+    })
+  })
+
   test('find route and parse route params', ({ assert }) => {
     async function handler() {}
 

--- a/tests/router/store.spec.ts
+++ b/tests/router/store.spec.ts
@@ -602,7 +602,7 @@ test.group('Store | match', () => {
     })
 
     store.add({
-      pattern: '/123',
+      pattern: '/user',
       handler,
       matchers: {},
       meta: {},
@@ -612,9 +612,9 @@ test.group('Store | match', () => {
       domain: 'root',
     })
 
-    assert.deepEqual(store.match('/123', 'GET'), {
+    assert.deepEqual(store.match('/user', 'GET'), {
       route: {
-        pattern: '/123',
+        pattern: '/user',
         handler,
         execute,
         middleware: new Middleware<any>(),
@@ -624,7 +624,22 @@ test.group('Store | match', () => {
       },
       params: {},
       subdomains: {},
-      routeKey: 'GET-/123',
+      routeKey: 'GET-/user',
+    })
+
+    assert.deepEqual(store.match('/USER', 'GET'), {
+      route: {
+        pattern: '/user',
+        handler,
+        execute,
+        middleware: new Middleware<any>(),
+        meta: {
+          params: [],
+        },
+      },
+      params: {},
+      subdomains: {},
+      routeKey: 'GET-/user',
     })
 
     assert.deepEqual(store.match('/12345', 'GET'), {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)


### 📚 Description

Related to : [How AdonisJS matches routes](https://docs.adonisjs.com/guides/basics/routing#how-adonisjs-matches-routes)

In the following example we **NEVER** going to reach the `/user` route.

```ts
import router from '@adonisjs/core/services/router'

router.get('/:id', ({ response }) => {
  return response.json({ from: 'callback - /:id' })
})

router.get('/user', ({ response }) => {
  return response.json({ from: 'USER ROUTE' })
})
```

After this PR you don't need to worry about the order of your routes. (I hope so, hehe)
> a url that matches the route pattern will have the highest priority


@thetutlage check out [how-adonisjs-matches-routes](https://docs.adonisjs.com/guides/basics/routing#how-adonisjs-matches-routes), I don't think we need this section anymore.
> I can open a PR for the docs if you want.
