### PR TITLE
feat: throw if HMR is enabled and controller is directly imported

### DIFF
--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -22,6 +22,12 @@ export const E_CANNOT_LOOKUP_ROUTE = createError<[routeIdentifier: string]>(
   500
 )
 
+export const E_DIRECT_CONTROLLER_IMPORT = createError<[controllerName: string]>(
+  'Cannot import controller "%s" directly with HMR enabled. Make sure to lazy import it',
+  'E_DIRECT_CONTROLLER_IMPORT',
+  500
+)
+
 export const E_HTTP_EXCEPTION = class HttpException extends Exception {
   body: any
   static code = 'E_HTTP_EXCEPTION'

--- a/src/router/route.ts
+++ b/src/router/route.ts
@@ -16,6 +16,7 @@ import { moduleCaller, moduleImporter } from '@adonisjs/fold'
 
 import { execute } from './executor.js'
 import { dropSlash } from '../helpers.js'
+import { E_DIRECT_CONTROLLER_IMPORT } from '../exceptions.js'
 import type { Constructor, LazyImport, OneOrMore } from '../types/base.js'
 
 import type {
@@ -162,6 +163,11 @@ export class Route<Controller extends Constructor<any> = any> extends Macroable 
        * The first item of the tuple is a class constructor
        */
       if (is.class(handler[0])) {
+        // @ts-expect-error - Dynamic property added by hot-hook
+        if (import.meta.hot) {
+          throw new E_DIRECT_CONTROLLER_IMPORT([handler[0].name])
+        }
+
         return {
           reference: handler,
           ...moduleCaller(handler[0], (handler[1] || 'handle') as string).toHandleMethod(),


### PR DESCRIPTION
Hey there! 👋🏻 

This PR will cause the router to throw the exception `E_DIRECT_CONTROLLER_IMPORT` if users directly import the controller and HMR is enabled.

**Why is this change needed?**

If HMR is enabled (and it is by default), we can only hot-replace code that has been layz imported. Since all controllers are marked as "boundary" by default, your code will simply break when not lazy-import them.

```ts
import HomeController from '#controllers/home_controller'

router.get('/', [HomeController, 'render'])
```

For example, with the code above, anytime I modify the `HomeController` code, I will see a message in my console saying the file was invalidated, but this is not the case, and my modification will never be taken into account unless I restart the process.

This is an issue that has been reported already multiple times since we activated HMR by default.