### PR TITLE
feat: add x-request-id to the response

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -380,6 +380,13 @@ export class Response extends Macroable {
 
     /*
      * ----------------------------------------
+     * SET X-REQUEST-ID HEADER
+     * ----------------------------------------
+     */
+    this.setRequestId()
+
+    /*
+     * ----------------------------------------
      * SET CONTENT-LENGTH HEADER
      * ----------------------------------------
      */
@@ -776,6 +783,18 @@ export class Response extends Macroable {
    */
   setEtag(body: any, weak: boolean = false): this {
     this.header('Etag', etag(body, { weak }))
+    return this
+  }
+
+  /**
+   * Set X-Request-Id header by copying the header value from the request if it exists.
+   *
+   */
+  setRequestId(): this {
+    const requestId = this.request.headers['x-request-id']
+    if (requestId) {
+      this.header('X-Request-Id', requestId)
+    }
     return this
   }
 

--- a/tests/response.spec.ts
+++ b/tests/response.spec.ts
@@ -108,6 +108,18 @@ test.group('Response', (group) => {
     })
   })
 
+  test('set x-request-id header', async () => {
+    const { url } = await httpServer.create((req, res) => {
+      req.headers['x-request-id'] = '20241127'
+      const response = new ResponseFactory().merge({ req, res, encryption, router }).create()
+
+      response.send('<p> hello </p>')
+      response.finish()
+    })
+
+    await supertest(url).get('/').expect(200).expect('x-request-id', '20241127')
+  })
+
   test('get merged from http res object', async ({ assert }) => {
     const { url } = await httpServer.create((req, res) => {
       res.setHeader('content-type', 'application/json')


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#93 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Add X-Request-Id to the response headers.
If the orignal request has the header or generateRequestId is set to true, the response will contains the X-Request-Id header.
Resolves #93 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
