### PR TITLE
Handle Uint8Array directly as a response, without converting to Buffer

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -224,7 +224,7 @@ export class Response extends Macroable {
    * - Buffer
    */
   #getDataType(content: any) {
-    if (Buffer.isBuffer(content)) {
+    if (content instanceof Uint8Array) {
       return 'buffer'
     }
 

--- a/tests/response.spec.ts
+++ b/tests/response.spec.ts
@@ -251,6 +251,17 @@ test.group('Response', (group) => {
     await supertest(url).get('/').expect('content-type', 'application/octet-stream; charset=utf-8')
   })
 
+  test('parse Uint8Array and set correct response header', async () => {
+    const { url } = await httpServer.create((req, res) => {
+      const response = new ResponseFactory().merge({ req, res, encryption, router }).create()
+
+      response.send(new Uint8Array(Buffer.from('hello')))
+      response.finish()
+    })
+
+    await supertest(url).get('/').expect('content-type', 'application/octet-stream; charset=utf-8')
+  })
+
   test('parse string and set correct response header', async ({ assert }) => {
     const { url } = await httpServer.create((req, res) => {
       const response = new ResponseFactory().merge({ req, res, encryption, router }).create()


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked discussion
https://github.com/orgs/adonisjs/discussions/4852
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This change allows returning a Uint8Array as a response, without needing to convert it to a Buffer.
The response class explicitly checks for a Buffer rather than an instance of Uint8Array, which could otherwise be used.
Puppeteer has switched to returning a Uint8Array instead of a Buffer so this change makes life a lot easier.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
