### PR TITLE
Group apiOnly()

### DIFF
--- a/src/router/group.ts
+++ b/src/router/group.ts
@@ -8,13 +8,13 @@
  */
 
 import Macroable from '@poppinss/macroable'
-import type { RouteMatcher, StoreRouteMiddleware } from '../types/route.js'
 import type { MiddlewareFn, ParsedNamedMiddleware } from '../types/middleware.js'
+import type { RouteMatcher, StoreRouteMiddleware } from '../types/route.js'
 
-import { Route } from './route.js'
+import { OneOrMore } from '../types/base.js'
 import { BriskRoute } from './brisk.js'
 import { RouteResource } from './resource.js'
-import { OneOrMore } from '../types/base.js'
+import { Route } from './route.js'
 
 /**
  * Group class exposes the API to take action on a group of routes.
@@ -239,5 +239,16 @@ export class RouteGroup extends Macroable {
    */
   middleware(middleware: OneOrMore<MiddlewareFn | ParsedNamedMiddleware>): this {
     return this.use(middleware)
+  }
+
+  /**
+   * Register api only for all route resources.
+   * The `create` and `edit` routes, which are meant to show forms will not be registered
+   */
+  apiOnly(): this {
+    this.routes
+      .filter((route) => route instanceof RouteResource)
+      .forEach((route) => route.apiOnly())
+    return this
   }
 }

--- a/tests/router/group.spec.ts
+++ b/tests/router/group.spec.ts
@@ -7,15 +7,15 @@
  * file that was distributed with this source code.
  */
 
-import { test } from '@japa/runner'
 import { AppFactory } from '@adonisjs/application/factories'
+import { test } from '@japa/runner'
 
-import { Route } from '../../src/router/route.js'
+import { defineNamedMiddleware } from '../../src/define_middleware.js'
 import { toRoutesJSON } from '../../src/helpers.js'
 import { BriskRoute } from '../../src/router/brisk.js'
 import { RouteGroup } from '../../src/router/group.js'
 import { RouteResource } from '../../src/router/resource.js'
-import { defineNamedMiddleware } from '../../src/define_middleware.js'
+import { Route } from '../../src/router/route.js'
 
 const BASE_URL = new URL('./app/', import.meta.url)
 
@@ -1299,5 +1299,28 @@ test.group('Route group | matchers', () => {
         handler,
       },
     ])
+  })
+})
+
+test.group('Route group | api only', () => {
+  test('mark non-api routes deleted', ({ assert, expectTypeOf }) => {
+    const app = new AppFactory().create(BASE_URL, () => {})
+    const resource = new RouteResource(app, [], {
+      resource: 'photos',
+      controller: '#controllers/photos',
+      globalMatchers: {},
+      shallow: true,
+    })
+
+    const group = new RouteGroup([resource])
+
+    group.apiOnly()
+
+    expectTypeOf(resource.apiOnly().only)
+      .parameter(0)
+      .toEqualTypeOf<('index' | 'store' | 'show' | 'update' | 'destroy')[]>()
+
+    assert.isTrue(resource.routes.find((route) => route.getName() === 'photos.create')!.isDeleted())
+    assert.isTrue(resource.routes.find((route) => route.getName() === 'photos.edit')!.isDeleted())
   })
 })

--- a/tests/router/resource.spec.ts
+++ b/tests/router/resource.spec.ts
@@ -7,8 +7,8 @@
  * file that was distributed with this source code.
  */
 
-import { test } from '@japa/runner'
 import { AppFactory } from '@adonisjs/application/factories'
+import { test } from '@japa/runner'
 
 import { RouteResource } from '../../src/router/resource.js'
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [X] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Adds `apiOnly()` on a group of routes, applying `apiOnly()` on all its resources.
It is very handy on some of my projects as it gives you a a clearer `routes.ts`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly. : https://github.com/adonisjs/v6-docs/pull/222
