### PR TITLE
add wildcard support for route matching

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -725,6 +725,12 @@ export class Request extends Macroable {
           return false
         }
 
+        if (identifier.includes('*')) {
+          const escaped = identifier.replace(/[-/\\^$+?.()|[\]{}]/g, '\\$&')
+          const regex = new RegExp('^' + escaped.replace(/\*/g, '.*') + '$')
+          return regex.test(route.name || route.pattern)
+        }
+
         return route.handler.reference === identifier
       }
     )

--- a/tests/request.spec.ts
+++ b/tests/request.spec.ts
@@ -944,6 +944,36 @@ test.group('Request', () => {
     })
   })
 
+  test('find if an wildcard identifiers matches the request route name', async ({ assert }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const request = new RequestFactory().merge({ req, res, encryption }).create()
+      request.ctx = new HttpContextFactory().merge({ request }).create()
+      ;(request.ctx.route as any) = {
+        pattern: '/users/:id',
+        name: 'admin.users.show',
+        handler: { name: '#controllers/user', handle: () => {} },
+      }
+
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          wildcard_trailing_match: request.matchesRoute(['admin.users.*']),
+          wildcard_middle_match: request.matchesRoute(['admin.*.show']),
+          wildcard_array_match: request.matchesRoute(['admin.posts.*', 'admin.users.*']),
+          wildcard_no_match: request.matchesRoute(['admin.invoices.*']),
+        })
+      )
+    })
+
+    const { body } = await supertest(url).get('/users/1')
+    assert.deepEqual(body, {
+      wildcard_trailing_match: true,
+      wildcard_middle_match: true,
+      wildcard_array_match: true,
+      wildcard_no_match: false,
+    })
+  })
+
   test('get request json representation', async ({ assert }) => {
     const { url } = await httpServer.create((req, res) => {
       const request = new RequestFactory().merge({ req, res, encryption }).create()


### PR DESCRIPTION
### ❓ Type of change
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
✨ **Added Wildcard Support to `matchesRoute`**
This feature introduces wildcard (`*`) matching support to the `matchesRoute` method.

Developers can now use conventions like `admin.users*` to match multiple routes based on a common prefix, similar to wildcard matching in other frameworks like Laravel.

**How it works:**
1.  If the route identifier contains a `*`, it is treated as a regular expression pattern.
2.  The `*` is converted to `.*` (match zero or more characters).
3.  The dot character (`.`) is escaped to treat it as a literal dot (`\\.`).
4.  The regex is tested against `route.name` and `route.pattern`.

**Example:**
* `admin.users.*` will match `admin.users.index`, `admin.users.create`, etc.
* `api.*.show` will match `api.posts.show`, `api.comments.show`, etc.

### 📝 Checklist
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
