### PR TITLE
Ensure x-request-id header is always set on responses

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -294,6 +294,13 @@ export class Response extends Macroable {
   protected writeBody(content: any, generateEtag: boolean, jsonpCallbackName?: string): void {
     const hasEmptyBody = content === null || content === undefined || content === ''
 
+    /*
+     * ----------------------------------------
+     * SET X-REQUEST-ID HEADER
+     * ----------------------------------------
+     */
+    this.setRequestId()
+
     /**
      * Set status to "204" when body is empty. The `safeStatus` method only
      * sets the status when no explicit status has been set already
@@ -406,13 +413,6 @@ export class Response extends Macroable {
       this.#endResponse(null, ResponseStatus.NotModified)
       return
     }
-
-    /*
-     * ----------------------------------------
-     * SET X-REQUEST-ID HEADER
-     * ----------------------------------------
-     */
-    this.setRequestId()
 
     /*
      * ----------------------------------------

--- a/tests/response.spec.ts
+++ b/tests/response.spec.ts
@@ -120,6 +120,18 @@ test.group('Response', (group) => {
     await supertest(url).get('/').expect(200).expect('x-request-id', '20241127')
   })
 
+  test('set x-request-id header when the response has no body', async () => {
+    const { url } = await httpServer.create((req, res) => {
+      req.headers['x-request-id'] = '20241127'
+      const response = new ResponseFactory().merge({ req, res, encryption, router }).create()
+
+      response.created()
+      response.finish()
+    })
+
+    await supertest(url).get('/').expect(201).expect('x-request-id', '20241127')
+  })
+
   test('get merged from http res object', async ({ assert }) => {
     const { url } = await httpServer.create((req, res) => {
       res.setHeader('content-type', 'application/json')


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

- https://github.com/adonisjs/http-server/issues/112

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously responses without a body would not have the x-request-id header set correctly. This change ensures that all responses are correctly decorated with the x-request-id header if necessary.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. — n/a
