### PR TITLE
feat(client): add defaultOptions to createUrlBuilder

### DIFF
--- a/src/client/url_builder.ts
+++ b/src/client/url_builder.ts
@@ -23,7 +23,8 @@ export function createUrlBuilder<Routes extends LookupList>(
   routesLoader:
     | { [domain: string]: ClientRouteJSON[] }
     | (() => { [domain: string]: ClientRouteJSON[] }),
-  searchParamsStringifier: (qs: Record<string, any>) => string
+  searchParamsStringifier: (qs: Record<string, any>) => string,
+  defaultOptions?: URLOptions
 ): UrlFor<Routes> {
   let domainsList: string[]
   let domainsRoutes: { [domain: string]: ClientRouteJSON[] }
@@ -56,12 +57,14 @@ export function createUrlBuilder<Routes extends LookupList>(
       throw new Error(`Cannot lookup route "${routeIdentifier}"`)
     }
 
+    const mergedOptions = defaultOptions || options ? { ...defaultOptions, ...options } : undefined
+
     return createURL(
       route.name ?? route.pattern,
       route.tokens,
       searchParamsStringifier,
       params,
-      options
+      mergedOptions
     )
   }
 

--- a/tests/client/url_builder.spec.ts
+++ b/tests/client/url_builder.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * @adonisjs/http-server
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { createUrlBuilder } from '../../src/client/url_builder.ts'
+import type { ClientRouteJSON } from '../../src/client/types.ts'
+
+function makeRoutes(routes: ClientRouteJSON[]) {
+  return { root: routes }
+}
+
+function stringifier(params: Record<string, any>) {
+  return new URLSearchParams(params).toString()
+}
+
+const usersIndex: ClientRouteJSON = {
+  name: 'users.index',
+  pattern: '/users',
+  tokens: [{ old: '/users', type: 0, val: 'users', end: '' }],
+  methods: ['GET'],
+  domain: 'root',
+}
+
+test.group('Client URLBuilder | defaultOptions', () => {
+  test('defaultOptions prefixUrl is applied to all generated URLs', ({ assert }) => {
+    const urlFor = createUrlBuilder(makeRoutes([usersIndex]), stringifier, {
+      prefixUrl: 'https://api.example.com',
+    })
+
+    assert.equal(urlFor('users.index'), 'https://api.example.com/users')
+  })
+
+  test('defaultOptions prefixUrl works with method-specific builders', ({ assert }) => {
+    const urlFor = createUrlBuilder(makeRoutes([usersIndex]), stringifier, {
+      prefixUrl: 'https://api.example.com',
+    })
+
+    assert.equal(urlFor.get('users.index').url, 'https://api.example.com/users')
+    assert.equal(urlFor.get('users.index').form.action, 'https://api.example.com/users')
+    assert.equal(`${urlFor.get('users.index')}`, 'https://api.example.com/users')
+  })
+
+  test('per-call prefixUrl overrides defaultOptions prefixUrl', ({ assert }) => {
+    const urlFor = createUrlBuilder(makeRoutes([usersIndex]), stringifier, {
+      prefixUrl: 'https://api.example.com',
+    })
+
+    assert.equal(
+      urlFor('users.index', undefined, { prefixUrl: 'https://other.com' }),
+      'https://other.com/users'
+    )
+  })
+
+  test('per-call options merge with defaultOptions', ({ assert }) => {
+    const urlFor = createUrlBuilder(makeRoutes([usersIndex]), stringifier, {
+      prefixUrl: 'https://api.example.com',
+    })
+
+    assert.equal(
+      urlFor('users.index', undefined, { qs: { page: 1 } }),
+      'https://api.example.com/users?page=1'
+    )
+  })
+
+  test('per-call prefixUrl empty string removes default prefix', ({ assert }) => {
+    const urlFor = createUrlBuilder(makeRoutes([usersIndex]), stringifier, {
+      prefixUrl: 'https://api.example.com',
+    })
+
+    assert.equal(urlFor('users.index', undefined, { prefixUrl: '' }), '/users')
+  })
+
+  test('defaultOptions qs is applied to all generated URLs', ({ assert }) => {
+    const urlFor = createUrlBuilder(makeRoutes([usersIndex]), stringifier, { qs: { version: '2' } })
+
+    assert.equal(urlFor('users.index'), '/users?version=2')
+  })
+
+  test('per-call qs overrides defaultOptions qs', ({ assert }) => {
+    const urlFor = createUrlBuilder(makeRoutes([usersIndex]), stringifier, { qs: { version: '2' } })
+
+    assert.equal(urlFor('users.index', undefined, { qs: { page: 1 } }), '/users?page=1')
+  })
+})


### PR DESCRIPTION
`createUrlBuilder` now accepts an optional third `defaultOptions` parameter. These defaults (e.g. `prefixUrl`) are automatically merged into every generated URL, so consumers don't have to repeat them on each call.

Per-call options still take precedence over defaults

```ts
const urlFor = createUrlBuilder(routes, stringifier, {
  prefixUrl: 'https://api.example.com'
})

urlFor('users.index') // https://api.example.com/users
urlFor('users.index', undefined, { prefixUrl: '' }) // /users (opt-out)
```

Also see https://github.com/Julien-R44/tuyau/issues/103 for why its needed