### PR TITLE
fix: pin tsdown to v0.20.x to prevent build issues fixes #116

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "reflect-metadata": "^0.2.2",
     "release-it": "^19.2.4",
     "supertest": "^7.2.2",
-    "tsdown": "^0.21.4",
+    "tsdown": "0.20.3",
     "typedoc": "^0.28.17",
     "typescript": "^5.9.3",
     "youch": "^4.1.0"


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#116 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Pinned tsdown to version 0.20.3 so it does not cause build issues

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
