### PR TITLE
fix: Router should be Macroable

### DIFF
--- a/src/router/main.ts
+++ b/src/router/main.ts
@@ -13,6 +13,7 @@ import type { Encryption } from '@boringnode/encryption'
 import type { Application } from '@adonisjs/application'
 import { RuntimeException } from '@poppinss/utils/exception'
 import type { Constructor, LazyImport } from '@poppinss/utils/types'
+import Macroable from '@poppinss/macroable'
 
 import debug from '../debug.ts'
 import type { Qs } from '../qs.ts'
@@ -60,7 +61,7 @@ import {
  * })
  * ```
  */
-export class Router {
+export class Router extends Macroable {
   /**
    * Flag to avoid re-comitting routes to the store
    */
@@ -152,6 +153,7 @@ export class Router {
    * @param qsParser - Query string parser for URL generation
    */
   constructor(app: Application<any>, encryption: Encryption, qsParser: Qs) {
+    super()
     this.#app = app
     this.#encryption = encryption
     this.qs = qsParser

--- a/tests/router/router.spec.ts
+++ b/tests/router/router.spec.ts
@@ -11,6 +11,7 @@ import { parse } from '@poppinss/qs'
 import { test } from '@japa/runner'
 import { EncryptionFactory } from '@boringnode/encryption/factories'
 
+import { Router } from '../../src/router/main.ts'
 import { RouterFactory } from '../../factories/router.ts'
 
 test.group('Router | add', () => {
@@ -1783,5 +1784,33 @@ test.group('Router | generateTypes', () => {
         'api.comments.destroy': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
       }"
     `)
+  })
+})
+
+test.group('Router | macroable', () => {
+  test('add macro to router', ({ assert }) => {
+    Router.macro('getRouteCount' as any, function (this: Router) {
+      return Object.values(this.toJSON()).flat().length
+    })
+
+    const router = new RouterFactory().create()
+    router.get('/', '#controllers/home.index')
+    router.commit()
+
+    // @ts-expect-error - macro is not typed
+    assert.equal(router.getRouteCount(), 1)
+  })
+
+  test('add getter to router', ({ assert }) => {
+    Router.getter('routeCount' as any, function (this: Router) {
+      return Object.values(this.toJSON()).flat().length
+    })
+
+    const router = new RouterFactory().create()
+    router.get('/', '#controllers/home.index')
+    router.commit()
+
+    // @ts-expect-error - getter is not typed
+    assert.equal(router.routeCount, 1)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

#80 — This was fixed in 7.x, but was broken during the refactor for 8.x which removed LookupStore.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change aligns the Router with the published documentation for 8.x: https://docs.adonisjs.com/guides/basics/routing#router

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to prevent further ocurrences of this regression.