### PR TITLE
feat: add request.boolean() for flexible boolean coercion

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -319,6 +319,87 @@ export class HttpRequest extends Macroable {
   }
 
   /**
+   * Returns the boolean value of a key from the request body or query
+   * string. Useful when working with HTML form submissions (checkboxes
+   * send `"on"`, hidden fields send `"1"`, etc.) or JSON clients that
+   * might send booleans as strings.
+   *
+   * Recognized truthy values:
+   * - booleans: `true`
+   * - strings: `"1"`, `"true"`, `"on"`, `"yes"` (case-insensitive, trimmed)
+   * - numbers: any non-zero, non-`NaN` number
+   * - arrays: a non-empty array
+   *
+   * Recognized falsy values:
+   * - booleans: `false`
+   * - strings: `"0"`, `"false"`, `"off"`, `"no"`, `""` (case-insensitive, trimmed)
+   * - numbers: `0`, `NaN`
+   * - arrays: an empty array
+   * - `null`, `undefined`
+   *
+   * If the value cannot be interpreted as a boolean (for example an
+   * object or a string like `"maybe"`), the `defaultValue` you pass as
+   * the second argument is returned. The same fallback is used when the
+   * key is missing from the request. If you don't pass a `defaultValue`,
+   * `false` is returned in those cases.
+   *
+   * @example
+   * ```js
+   * // form checkbox sent "on"
+   * request.boolean('subscribe')              // true
+   *
+   * // hidden field sent "0"
+   * request.boolean('dark_mode')              // false
+   *
+   * // missing key, you decide the default
+   * request.boolean('agreed', false)          // false
+   * request.boolean('agreed', true)           // true
+   * ```
+   * @param key - Key to lookup in request data
+   * @param defaultValue - Value to return when the key is missing or the value is not a recognized boolean
+   * @returns Boolean interpretation of the request data value
+   */
+  boolean(key: string, defaultValue?: boolean): boolean {
+    const value = lodash.get(this.#requestData, key)
+
+    if (value === undefined) {
+      return defaultValue ?? false
+    }
+
+    if (typeof value === 'boolean') {
+      return value
+    }
+
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase()
+      if (['', '0', 'false', 'off', 'no'].includes(normalized)) {
+        return false
+      }
+      if (['1', 'true', 'on', 'yes'].includes(normalized)) {
+        return true
+      }
+      return defaultValue ?? false
+    }
+
+    if (typeof value === 'number') {
+      if (Number.isNaN(value)) {
+        return defaultValue ?? false
+      }
+      return value !== 0
+    }
+
+    if (value === null) {
+      return defaultValue ?? false
+    }
+
+    if (Array.isArray(value)) {
+      return value.length > 0
+    }
+
+    return defaultValue ?? false
+  }
+
+  /**
    * Returns value for a given key from route params
    *
    * @example

--- a/tests/request.spec.ts
+++ b/tests/request.spec.ts
@@ -240,6 +240,191 @@ test.group('Request', () => {
     })
   })
 
+  test('convert truthy query string values to boolean', async ({ assert }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const request = new HttpRequestFactory().merge({ req, res, encryption }).create()
+
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          one: request.boolean('one'),
+          trueValue: request.boolean('trueValue'),
+          on: request.boolean('on'),
+          yes: request.boolean('yes'),
+          upper: request.boolean('upper'),
+        })
+      )
+    })
+
+    const { body } = await supertest(url).get('/?one=1&trueValue=true&on=on&yes=yes&upper=TRUE')
+    assert.deepEqual(body, {
+      one: true,
+      trueValue: true,
+      on: true,
+      yes: true,
+      upper: true,
+    })
+  })
+
+  test('convert falsy query string values to boolean', async ({ assert }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const request = new HttpRequestFactory().merge({ req, res, encryption }).create()
+
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          zero: request.boolean('zero'),
+          falseValue: request.boolean('falseValue'),
+          off: request.boolean('off'),
+          no: request.boolean('no'),
+          empty: request.boolean('empty'),
+          upper: request.boolean('upper'),
+        })
+      )
+    })
+
+    const { body } = await supertest(url).get(
+      '/?zero=0&falseValue=false&off=off&no=no&empty=&upper=FALSE'
+    )
+    assert.deepEqual(body, {
+      zero: false,
+      falseValue: false,
+      off: false,
+      no: false,
+      empty: false,
+      upper: false,
+    })
+  })
+
+  test('read boolean from request body', async ({ assert }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const request = new HttpRequestFactory().merge({ req, res, encryption }).create()
+      request.setInitialBody({ isAdmin: 'true', darkMode: '0' })
+
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          isAdmin: request.boolean('isAdmin'),
+          darkMode: request.boolean('darkMode'),
+        })
+      )
+    })
+
+    const { body } = await supertest(url).get('/')
+    assert.deepEqual(body, {
+      isAdmin: true,
+      darkMode: false,
+    })
+  })
+
+  test('read nested boolean from request data', async ({ assert }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const request = new HttpRequestFactory().merge({ req, res, encryption }).create()
+      request.setInitialBody({ user: { verified: 'yes', blocked: 'no' } })
+
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          verified: request.boolean('user.verified'),
+          blocked: request.boolean('user.blocked'),
+        })
+      )
+    })
+
+    const { body } = await supertest(url).get('/')
+    assert.deepEqual(body, {
+      verified: true,
+      blocked: false,
+    })
+  })
+
+  test('return default value when boolean key is missing', async ({ assert }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const request = new HttpRequestFactory().merge({ req, res, encryption }).create()
+
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          defaultFalse: request.boolean('missing'),
+          defaultTrue: request.boolean('missing', true),
+        })
+      )
+    })
+
+    const { body } = await supertest(url).get('/')
+    assert.deepEqual(body, {
+      defaultFalse: false,
+      defaultTrue: true,
+    })
+  })
+
+  test('return default value for unrecognized boolean values', async ({ assert }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const request = new HttpRequestFactory().merge({ req, res, encryption }).create()
+      request.setInitialBody({ weird: 'maybe', obj: { foo: 'bar' } })
+
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          weird: request.boolean('weird', true),
+          obj: request.boolean('obj', true),
+          nullValue: request.boolean('nullValue', true),
+        })
+      )
+    })
+
+    const { body } = await supertest(url).get('/?nullValue=')
+    assert.deepEqual(body, {
+      weird: true,
+      obj: true,
+      nullValue: false,
+    })
+  })
+
+  test('convert numeric values to boolean', async ({ assert }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const request = new HttpRequestFactory().merge({ req, res, encryption }).create()
+      request.setInitialBody({ count: 5, zero: 0, nothing: null })
+
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          count: request.boolean('count'),
+          zero: request.boolean('zero'),
+          nothing: request.boolean('nothing'),
+        })
+      )
+    })
+
+    const { body } = await supertest(url).get('/')
+    assert.deepEqual(body, {
+      count: true,
+      zero: false,
+      nothing: false,
+    })
+  })
+
+  test('convert array values to boolean', async ({ assert }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const request = new HttpRequestFactory().merge({ req, res, encryption }).create()
+      request.setInitialBody({ tags: ['a'], empty: [] })
+
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          tags: request.boolean('tags'),
+          empty: request.boolean('empty'),
+        })
+      )
+    })
+
+    const { body } = await supertest(url).get('/')
+    assert.deepEqual(body, {
+      tags: true,
+      empty: false,
+    })
+  })
+
   test('get all except few keys', async ({ assert }) => {
     const { url } = await httpServer.create((req, res) => {
       const request = new HttpRequestFactory().merge({ req, res, encryption }).create()


### PR DESCRIPTION
### 🔗 Linked issue

N/A — feature request, discussion: <link to your discussion thread>

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a new `request.boolean(key, defaultValue?)` method on `HttpRequest` that coerces a value from the request body or query string into a proper boolean. It accepts the common truthy/falsy forms sent by HTML forms (`"on"`, `"1"`, `"yes"`) and JSON clients (`"true"`, `"false"`, etc.), so callers no longer have to write `request.input('flag') === 'on'` style boilerplate.

**Why?** Today, reading a boolean from a form or JSON body is awkward — booleans arrive as strings (`"true"`, `"on"`, `"1"`, `"0"`) and the developer is responsible for the coercion. This helper centralizes that logic and matches a familiar API.

**Usage**
```ts
// HTML form checkbox sent "on" / hidden field sent "0"
request.boolean('subscribe')        // true
request.boolean('dark_mode')        // false

// Missing key — you decide the default
request.boolean('agreed', false)    // false
request.boolean('agreed', true)     // true
```

**Recognized values**

| Input | Result |
| --- | --- |
| `true` | `true` |
| `"1"`, `"true"`, `"on"`, `"yes"` (case-insensitive, trimmed) | `true` |
| any non-zero, non-`NaN` number | `true` |
| non-empty array | `true` |
| `false` | `false` |
| `"0"`, `"false"`, `"off"`, `"no"`, `""` (case-insensitive, trimmed) | `false` |
| `0`, `NaN` | `false` |
| empty array | `false` |
| `null`, `undefined`, or any unrecognized value (object, weird string, etc.) | `defaultValue` (or `false` if omitted) |
| key missing from request data | `defaultValue` (or `false` if omitted) |

**Notes**

- The second argument is optional with **no baked-in default** — callers must opt in to a custom fallback. This keeps the contract explicit.
- Nested keys are supported (e.g. `request.boolean('user.verified')`).
- 8 new tests added in `tests/request.spec.ts` covering: truthy/falsy strings, body data, nested keys, missing keys, unrecognized values, numeric coercion, and array coercion.

### 📝 Checklist

- [x] I have linked an issue or discussion. (link to discussion thread)
- [ ] I have updated the documentation accordingly. (happy to open a follow-up docs PR in `adonisjs/docs` once this lands)