### PR TITLE
fix(benchmarks): update encryption setup

### DIFF
--- a/benchmarks/adonisjs.js
+++ b/benchmarks/adonisjs.js
@@ -10,7 +10,7 @@
 import { createServer } from 'node:http'
 import { Logger } from '@adonisjs/logger'
 import { Emitter } from '@adonisjs/events'
-import { Encryption } from '@boringnode/encryption'
+import { EncryptionFactory } from '@boringnode/encryption/factories'
 import { Application } from '@adonisjs/application'
 
 import { defineConfig, Server } from '../build/index.js'
@@ -21,7 +21,7 @@ const app = new Application(new URL('./', import.meta.url), {
 })
 await app.init()
 
-const encryption = new Encryption({ secret: 'averylongrandom32charslongsecret' })
+const encryption = new EncryptionFactory().create()
 
 const server = new Server(
   app,


### PR DESCRIPTION
## Summary

- use the encryption factory compatible with `@boringnode/encryption` 1.x
- restore the AdonisJS benchmark server startup

## Verification

- `npm run lint`
- started `node benchmarks/adonisjs.js` and verified `GET /` returns `{"hello":"world"}`