### PR TITLE
perf(server): skip tracing wrappers when no channel has subscribers

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -16,6 +16,28 @@ You can run the same benchmarks by cloning the repo and then running the followi
 npm run benchmark
 ```
 
+This workload measures the complete HTTP request pipeline with one static `GET /` route. It does not measure how routing performance changes with route count or alternating URLs.
+
+## Router benchmark
+
+The router benchmark registers 1,000 static routes and 100 dynamic routes in both AdonisJS HTTP Server and Fastify. It measures the first and last static and dynamic routes, alternating static and dynamic URLs, and URLs spread over the whole table.
+
+```sh
+npm run benchmark:router
+```
+
+Each scenario runs for 10 seconds after a shared warmup. The workload can be adjusted with `BENCH_DURATION`, `BENCH_WARMUP_DURATION`, `BENCH_CONNECTIONS`, `BENCH_PIPELINING`, `BENCH_STATIC_ROUTES`, and `BENCH_DYNAMIC_ROUTES`. Set `BENCH_OUTPUT` to save the raw results as JSON and `BENCH_LABEL` to identify the run.
+
+`BENCH_SHAPE` selects how the route table is built. `uniform` (the default) declares every static route before any dynamic one and has no catch-all. `app` mirrors how routes accumulate in a real application: a dynamic route appears early among the static ones, and a top level param route plus a catch-all close the file. Route matching is sensitive to both, so a router change should be measured against each.
+
+```sh
+BENCH_SHAPE=app BENCH_STATIC_ROUTES=60 BENCH_DYNAMIC_ROUTES=20 npm run benchmark:router
+```
+
+Scenarios built from a single path measure a repeated URL, which per-URL memoisation answers without running the matcher. The `varied-*` scenarios spread requests across the table and are the ones that reflect mixed traffic.
+
+See the [recorded before-and-after results](benchmarks/results/router-comparison.md) for both table shapes.
+
 Since the program correctness and reliability is more important over micro optimizations. We pay penalty on following fronts in comparison to Fastify.
 
 - **The AdonisJS query string parser can parse arrays inside the query string** `(/api?foo[]=bar&foo[]=fuzz&foo[]=buzz

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -36,6 +36,12 @@ BENCH_SHAPE=app BENCH_STATIC_ROUTES=60 BENCH_DYNAMIC_ROUTES=20 npm run benchmark
 
 Scenarios built from a single path measure a repeated URL, which per-URL memoisation answers without running the matcher. The `varied-*` scenarios spread requests across the table and are the ones that reflect mixed traffic.
 
+`BENCH_MIDDLEWARE_COUNT` registers that many middleware in both servers, and `BENCH_MIDDLEWARE_KIND` chooses what they do. The default middleware returns `next()` and nothing else, which measures the machinery around it rather than a realistic request. `realistic` awaits, reads a header and allocates, which is still less work than session, auth or CSRF middleware perform. Anything measuring per-middleware overhead should be reported against `realistic`.
+
+```sh
+BENCH_MIDDLEWARE_COUNT=6 BENCH_MIDDLEWARE_KIND=realistic npm run benchmark:router
+```
+
 See the [recorded before-and-after results](benchmarks/results/router-comparison.md) for both table shapes.
 
 Since the program correctness and reliability is more important over micro optimizations. We pay penalty on following fronts in comparison to Fastify.

--- a/benchmarks/results/router-app-after-1.json
+++ b/benchmarks/results/router-app-after-1.json
@@ -1,0 +1,128 @@
+{
+  "label": "fixed2",
+  "timestamp": "2026-08-17T20:04:29.136Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 60,
+    "dynamicRoutes": 20,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 10,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 152279.28,
+      "latency": 6.08
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 153070.55,
+      "latency": 6.05
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 148043.64,
+      "latency": 6.21
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 148672,
+      "latency": 6.19
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 151965.1,
+      "latency": 6.08
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 140549.82,
+      "latency": 6.51
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 151732.37,
+      "latency": 6.08
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 138234.19,
+      "latency": 6.89
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 143458.91,
+      "latency": 6.31
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 115488,
+      "latency": 8.02
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 115109.82,
+      "latency": 8.01
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 115330.91,
+      "latency": 8.02
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 115371.64,
+      "latency": 8.02
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 115592.73,
+      "latency": 7.98
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 114818.91,
+      "latency": 8.03
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 114725.82,
+      "latency": 8.07
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 114638.55,
+      "latency": 8.09
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 113911.28,
+      "latency": 8.17
+    }
+  ]
+}

--- a/benchmarks/results/router-app-after-2.json
+++ b/benchmarks/results/router-app-after-2.json
@@ -1,0 +1,128 @@
+{
+  "label": "fixed3",
+  "timestamp": "2026-08-17T20:08:24.183Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 60,
+    "dynamicRoutes": 20,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 10,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 154245.82,
+      "latency": 5.98
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 154234.19,
+      "latency": 6
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 149661.1,
+      "latency": 6.19
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 149312,
+      "latency": 6.21
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 152942.55,
+      "latency": 6.06
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 140747.64,
+      "latency": 6.5
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 151732.37,
+      "latency": 6.09
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 139339.64,
+      "latency": 6.79
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 144587.64,
+      "latency": 6.26
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 114725.82,
+      "latency": 8.04
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 115598.55,
+      "latency": 8.01
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 114958.55,
+      "latency": 8.04
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 114656,
+      "latency": 8.07
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 115866.19,
+      "latency": 7.97
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 114365.1,
+      "latency": 8.09
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 114749.1,
+      "latency": 8.12
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 115266.91,
+      "latency": 8.06
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 114400,
+      "latency": 8.17
+    }
+  ]
+}

--- a/benchmarks/results/router-app-before.json
+++ b/benchmarks/results/router-app-before.json
@@ -1,0 +1,128 @@
+{
+  "label": "official",
+  "timestamp": "2026-08-17T19:52:18.092Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 60,
+    "dynamicRoutes": 20,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 10,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 148090.19,
+      "latency": 6.21
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 134056.73,
+      "latency": 7.11
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 141527.28,
+      "latency": 6.4
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 136965.82,
+      "latency": 6.9
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 139665.46,
+      "latency": 6.66
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 138164.37,
+      "latency": 6.79
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 140596.37,
+      "latency": 6.66
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 139072,
+      "latency": 6.81
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 138816,
+      "latency": 6.82
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 113893.82,
+      "latency": 8.12
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 113736.73,
+      "latency": 8.13
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 113585.46,
+      "latency": 8.15
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 113108.37,
+      "latency": 8.21
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 113608.73,
+      "latency": 8.13
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 113073.46,
+      "latency": 8.24
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 113422.55,
+      "latency": 8.34
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 112107.64,
+      "latency": 8.54
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 111758.55,
+      "latency": 8.58
+    }
+  ]
+}

--- a/benchmarks/results/router-app-prefix-index-only.json
+++ b/benchmarks/results/router-app-prefix-index-only.json
@@ -1,0 +1,128 @@
+{
+  "label": "pr",
+  "timestamp": "2026-08-17T19:55:48.614Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 60,
+    "dynamicRoutes": 20,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 10,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 153152,
+      "latency": 6.04
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 152837.82,
+      "latency": 6.06
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 148916.37,
+      "latency": 6.19
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 148753.46,
+      "latency": 6.21
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 145122.91,
+      "latency": 6.26
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 135104,
+      "latency": 7.06
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 139537.46,
+      "latency": 6.69
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 133184,
+      "latency": 7.1
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 135360,
+      "latency": 7.05
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 114446.55,
+      "latency": 8.09
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 113341.1,
+      "latency": 8.2
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 113306.19,
+      "latency": 8.21
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 113742.55,
+      "latency": 8.14
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 114673.46,
+      "latency": 8.06
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 113754.19,
+      "latency": 8.14
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 114475.64,
+      "latency": 8.12
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 113352.73,
+      "latency": 8.26
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 112928,
+      "latency": 8.33
+    }
+  ]
+}

--- a/benchmarks/results/router-comparison.md
+++ b/benchmarks/results/router-comparison.md
@@ -96,3 +96,35 @@ At this table size a plain scan over every route is already cheap, which is why 
 - [`router-app-prefix-index-only.json`](./router-app-prefix-index-only.json)
 - [`router-app-after-1.json`](./router-app-after-1.json)
 - [`router-app-after-2.json`](./router-app-after-2.json)
+
+## Tracing fast path
+
+Every request handler, middleware, response serialization and error handler ran inside a `diagnostics_channel` tracing wrapper, whether or not anything was subscribed to those channels. The wrapper allocates a context object, publishes to the start channel, attaches promise continuations and publishes again on settle. With no subscriber that work is thrown away.
+
+The fast path calls the target directly when the channel reports no subscribers, and leaves the traced path untouched otherwise. `hasSubscribers` was already read on every one of those calls to decide the context argument, so the check itself is not new.
+
+### Method
+
+Measured with `BENCH_MIDDLEWARE_KIND=realistic`, which registers middleware that awaits, reads a header and allocates. The default benchmark middleware only returns `next()`, and against it the wrapper is close to the entire cost of a middleware, which overstates the result. Both servers register the same middleware, and Fastify is reported as a control.
+
+Averages across all nine scenarios, 8 seconds each.
+
+| Middleware | before | after | Raw | Fastify control | Control-adjusted |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 20 | 55,626 | 56,508 | +1.59% | −0.00% | **+1.59%** |
+| 6, run 1 | 96,517 | 97,090 | +0.59% | +1.50% | −0.91% |
+| 6, run 2 | 95,886 | 97,806 | +2.00% | +0.79% | +1.21% |
+
+### Reading
+
+What is removed is a fixed cost per instrumented call site, not a share of the work a middleware performs, so the saving grows with the number of middleware rather than with how heavy they are. At 20 middleware it is about 0.3 µs per request across the roughly two dozen traced call sites a request passes through.
+
+At 20 middleware the improvement is consistent and larger than the control drift. At 6 middleware, closer to what a default AdonisJS kernel registers, the two runs land on opposite sides of zero, so the effect is at or below the noise floor of this setup and should not be quoted as a number. With no middleware there is nothing measurable, which is expected: only four call sites remain.
+
+Anyone reproducing this should run both revisions more than once and report the control, because the run-to-run drift here is comparable to the effect being measured.
+
+### Raw results
+
+- [`router-tracing-mw20-before.json`](./router-tracing-mw20-before.json) / [`router-tracing-mw20-after.json`](./router-tracing-mw20-after.json)
+- [`router-tracing-mw6-before.json`](./router-tracing-mw6-before.json) / [`router-tracing-mw6-after.json`](./router-tracing-mw6-after.json)
+- [`router-tracing-mw6-before-2.json`](./router-tracing-mw6-before-2.json) / [`router-tracing-mw6-after-2.json`](./router-tracing-mw6-after-2.json)

--- a/benchmarks/results/router-comparison.md
+++ b/benchmarks/results/router-comparison.md
@@ -1,0 +1,98 @@
+# Router benchmark comparison
+
+The existing `npm run benchmark` workload is an end-to-end HTTP benchmark with one static `GET /` route. It is useful for measuring the complete request pipeline, but it is not a router scalability benchmark: the matcher always checks the first and only route, using the same URL on every request.
+
+The `npm run benchmark:router` workload registers many routes and measures first, last, alternating and varied URLs, so route count, declaration order and cache locality are all visible.
+
+## Environment
+
+- CPU: Apple M4
+- Memory: 32 GiB
+- OS: Darwin 24.6.0 arm64
+- Node.js: 24.19.0
+- Connections: 100
+- Pipelining: 10
+- Warmup: 3 seconds per framework
+- Measurement: 10 seconds per scenario
+- Baseline: `9.x` at `9088623`, with this branch's benchmark workload applied on top
+- Optimized: this branch
+
+Fastify runs in every measurement as a control. Its numbers are reported next to each table so machine drift between runs stays visible.
+
+## Two route table shapes
+
+The route table is generated in one of two shapes, selected with `BENCH_SHAPE`.
+
+`uniform` (the default) declares every static route before any dynamic one and has no catch-all. `app` mirrors how routes accumulate in a real application: a dynamic route appears early among the static ones, and a top level param route plus a catch-all close the file. Both shapes resolve the benchmark URLs to the same routes, because the trailing routes only capture URLs nothing else matches.
+
+The shape matters. Declaration order decides whether static routes can be indexed for exact lookup, and a top level param or catch-all route is a candidate for every URL.
+
+## Scenarios
+
+Scenarios built from a single path measure a repeated URL, which any per-URL memoisation answers without running the matcher at all. The `varied-*` scenarios spread requests over 25 paths across the whole table and are the ones that reflect what mixed traffic pays.
+
+## Large table, uniform shape
+
+1,000 static routes and 100 dynamic routes.
+
+| Scenario | before | after | Change | Fastify before | Fastify after |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| static-first | 146,531 | 152,943 | +4.38% | 115,500 | 115,924 |
+| static-last | 51,492 | 153,769 | +198.63% | 115,203 | 115,348 |
+| dynamic-first | 95,031 | 149,021 | +56.81% | 113,952 | 115,488 |
+| dynamic-last | 84,518 | 148,567 | +75.78% | 115,418 | 114,697 |
+| alternating-static | 74,272 | 151,535 | +104.03% | 114,784 | 114,714 |
+| alternating-dynamic | 88,881 | 140,119 | +57.65% | 114,447 | 114,877 |
+| varied-static | 77,501 | 151,383 | +95.33% | 113,597 | 114,202 |
+| varied-dynamic | 89,318 | 137,559 | +54.01% | 114,522 | 114,220 |
+| varied-mixed | 81,667 | 142,900 | +74.98% | 113,760 | 114,185 |
+
+The control moved by 0.4% on average, so these differences are not machine drift. Throughput no longer depends on where a route sits in the table.
+
+## Small table, app shape
+
+60 static routes, 20 dynamic routes, one dynamic route declared early, and a top level param route plus a catch-all at the end: 83 GET routes in total. This is the size and shape of a typical application, and it is the case the earlier revision of this branch regressed.
+
+The middle column is an intermediate revision measured while developing this branch: the static prefix index alone, before static routes were indexed independently of declaration order and before the routes without a static prefix were merged into the groups. It is included because it is what the original workload failed to catch.
+
+| Scenario | before | prefix index only | after |
+| --- | ---: | ---: | ---: |
+| static-first | 148,090 | 153,152 | 153,263 |
+| static-last | 134,057 | 152,838 | 153,653 |
+| dynamic-first | 141,527 | 148,916 | 148,853 |
+| dynamic-last | 136,966 | 148,753 | 148,992 |
+| alternating-static | 139,665 | 145,123 | 152,454 |
+| alternating-dynamic | 138,164 | 135,104 | 140,649 |
+| varied-static | 140,596 | 139,537 | 151,732 |
+| varied-dynamic | 139,072 | 133,184 | 138,787 |
+| varied-mixed | 138,816 | 135,360 | 144,024 |
+
+| | before | prefix index only | after |
+| --- | ---: | ---: | ---: |
+| Fastify control, average | 113,088 | 113,760 | 114,986 |
+
+The `after` column averages two runs. Repeated runs of the same revision varied by 0.8%, and the control drifted by 1.7% between the `before` and `after` runs, so differences below roughly 2% are not meaningful here.
+
+Against that noise floor:
+
+- `varied-static` and `varied-mixed` were flat or slower with the prefix index alone and are now 7.9% and 3.8% faster. The exact lookup for static routes is what moved them, and it only applies once static routes are indexed regardless of where they are declared.
+- `alternating-dynamic` and `varied-dynamic` were 2.2% and 4.2% slower with the prefix index alone. They are back at parity. Both alternate or spread URLs, so the last-match memo never answers them and every request went through the merge and sort that the prefix index used to perform.
+- The single-path scenarios are unchanged between the middle and last column: the memo answers them, so they never exercise the matcher.
+
+At this table size a plain scan over every route is already cheap, which is why the store falls back to it below `SMALL_TABLE_ROUTES` routes per domain and method.
+
+## What produces the difference
+
+- **Exact lookup for static routes.** A static route joins a hash table keyed by its pattern unless an earlier route matches it. Registration order does not decide whether the table is populated, only actual shadowing does.
+- **Static prefix narrowing.** Routes are grouped by their leading static segments. A request consults only the groups whose prefix its URL starts with. Groups also carry the routes that have no static prefix, so a catch-all does not force a second pass.
+- **Registration order is preserved.** Each group is matched on its own and the winner with the lowest registration index wins, which selects the same route as matching the whole table in order. Regex matchers, casts, optional parameters and wildcards keep working unchanged.
+- **Small tables skip the index.** Slicing the path at every segment boundary costs more than scanning a short table, so the index is only consulted past `SMALL_TABLE_ROUTES` routes.
+
+## Raw results
+
+- [`router-large-before.json`](./router-large-before.json)
+- [`router-large-after.json`](./router-large-after.json)
+- [`router-app-before.json`](./router-app-before.json)
+- [`router-app-prefix-index-only.json`](./router-app-prefix-index-only.json)
+- [`router-app-after-1.json`](./router-app-after-1.json)
+- [`router-app-after-2.json`](./router-app-after-2.json)

--- a/benchmarks/results/router-large-after.json
+++ b/benchmarks/results/router-large-after.json
@@ -1,0 +1,128 @@
+{
+  "label": "fixed-large",
+  "timestamp": "2026-08-17T20:15:41.584Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 1000,
+    "dynamicRoutes": 100,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 10,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 152942.55,
+      "latency": 6.06
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 153768.73,
+      "latency": 6.02
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 149021.1,
+      "latency": 6.2
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 148567.28,
+      "latency": 6.21
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 151534.55,
+      "latency": 6.1
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 140119.28,
+      "latency": 6.56
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 151383.28,
+      "latency": 6.1
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 137559.28,
+      "latency": 6.94
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 142900.37,
+      "latency": 6.35
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 115924.37,
+      "latency": 7.99
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 115348.37,
+      "latency": 8
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 115488,
+      "latency": 8
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 114696.73,
+      "latency": 8.05
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 114714.19,
+      "latency": 8.04
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 114877.1,
+      "latency": 8.05
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 114202.19,
+      "latency": 8.18
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 114219.64,
+      "latency": 8.16
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 114184.73,
+      "latency": 8.21
+    }
+  ]
+}

--- a/benchmarks/results/router-large-before.json
+++ b/benchmarks/results/router-large-before.json
@@ -1,0 +1,128 @@
+{
+  "label": "official-large",
+  "timestamp": "2026-08-17T20:12:10.336Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 1000,
+    "dynamicRoutes": 100,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 10,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 146530.91,
+      "latency": 6.25
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 51492.37,
+      "latency": 18.9
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 95031.28,
+      "latency": 10.02
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 84518.4,
+      "latency": 11.38
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 74272,
+      "latency": 12.94
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 88881.46,
+      "latency": 10.7
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 77501.1,
+      "latency": 12.39
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 89317.82,
+      "latency": 10.64
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 81666.91,
+      "latency": 11.78
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 115499.64,
+      "latency": 8.06
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 115202.91,
+      "latency": 8.06
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 113952,
+      "latency": 8.19
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 115418.19,
+      "latency": 8.08
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 114784,
+      "latency": 8.12
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 114446.55,
+      "latency": 8.17
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 113597.1,
+      "latency": 8.29
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 114522.19,
+      "latency": 8.1
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 113760,
+      "latency": 8.25
+    }
+  ]
+}

--- a/benchmarks/results/router-tracing-mw20-after.json
+++ b/benchmarks/results/router-tracing-mw20-after.json
@@ -1,0 +1,129 @@
+{
+  "label": "mw20-after",
+  "timestamp": "2026-08-17T22:06:58.474Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 1000,
+    "dynamicRoutes": 100,
+    "middlewareCount": 20,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 8,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 57116,
+      "latency": 16.96
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 57388,
+      "latency": 16.9
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 56836,
+      "latency": 17.06
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 56924,
+      "latency": 17.02
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 57188,
+      "latency": 16.94
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 55804,
+      "latency": 17.41
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 56876,
+      "latency": 17.06
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 55228,
+      "latency": 17.63
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 55216,
+      "latency": 17.64
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 105144,
+      "latency": 9.08
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 105920,
+      "latency": 9
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 105848,
+      "latency": 9
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 105560,
+      "latency": 9.02
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 106104,
+      "latency": 9
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 105640,
+      "latency": 9.02
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 105152,
+      "latency": 9.02
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 105008,
+      "latency": 9.03
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 105080,
+      "latency": 9.04
+    }
+  ]
+}

--- a/benchmarks/results/router-tracing-mw20-before.json
+++ b/benchmarks/results/router-tracing-mw20-before.json
@@ -1,0 +1,129 @@
+{
+  "label": "mw20-before",
+  "timestamp": "2026-08-17T22:04:19.222Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 1000,
+    "dynamicRoutes": 100,
+    "middlewareCount": 20,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 8,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 56000,
+      "latency": 17.33
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 56208,
+      "latency": 17.28
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 55916,
+      "latency": 17.38
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 55812,
+      "latency": 17.43
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 56116,
+      "latency": 17.33
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 54800,
+      "latency": 17.77
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 56096,
+      "latency": 17.35
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 54544,
+      "latency": 17.85
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 55144,
+      "latency": 17.68
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 106120,
+      "latency": 8.98
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 105680,
+      "latency": 8.99
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 105696,
+      "latency": 8.99
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 105320,
+      "latency": 9.01
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 106048,
+      "latency": 8.97
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 105360,
+      "latency": 9.02
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 105488,
+      "latency": 8.99
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 105392,
+      "latency": 9
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 104392,
+      "latency": 9.08
+    }
+  ]
+}

--- a/benchmarks/results/router-tracing-mw6-after-2.json
+++ b/benchmarks/results/router-tracing-mw6-after-2.json
@@ -1,0 +1,129 @@
+{
+  "label": "mw6-after-2",
+  "timestamp": "2026-08-17T22:12:25.970Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 1000,
+    "dynamicRoutes": 100,
+    "middlewareCount": 6,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 8,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 99480,
+      "latency": 9.51
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 99888,
+      "latency": 9.49
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 98424,
+      "latency": 9.74
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 98640,
+      "latency": 9.71
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 99232,
+      "latency": 9.57
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 95352,
+      "latency": 10.06
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 99024,
+      "latency": 9.69
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 94000,
+      "latency": 10.15
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 96216,
+      "latency": 10
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 108104,
+      "latency": 8.88
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 107608,
+      "latency": 8.9
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 107360,
+      "latency": 8.92
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 107424,
+      "latency": 8.91
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 107632,
+      "latency": 8.88
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 107008,
+      "latency": 8.92
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 107208,
+      "latency": 8.9
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 106664,
+      "latency": 8.92
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 106480,
+      "latency": 8.93
+    }
+  ]
+}

--- a/benchmarks/results/router-tracing-mw6-after.json
+++ b/benchmarks/results/router-tracing-mw6-after.json
@@ -1,0 +1,129 @@
+{
+  "label": "mw6-after",
+  "timestamp": "2026-08-17T22:01:28.440Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 1000,
+    "dynamicRoutes": 100,
+    "middlewareCount": 6,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 8,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 98912,
+      "latency": 9.64
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 99288,
+      "latency": 9.59
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 97992,
+      "latency": 9.77
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 97864,
+      "latency": 9.82
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 98720,
+      "latency": 9.69
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 94728,
+      "latency": 10.09
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 98736,
+      "latency": 9.75
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 92440,
+      "latency": 10.31
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 95128,
+      "latency": 10.06
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 108808,
+      "latency": 8.84
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 108520,
+      "latency": 8.88
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 108312,
+      "latency": 8.89
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 107992,
+      "latency": 8.91
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 108424,
+      "latency": 8.87
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 107840,
+      "latency": 8.89
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 107816,
+      "latency": 8.89
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 107304,
+      "latency": 8.91
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 106648,
+      "latency": 8.96
+    }
+  ]
+}

--- a/benchmarks/results/router-tracing-mw6-before-2.json
+++ b/benchmarks/results/router-tracing-mw6-before-2.json
@@ -1,0 +1,129 @@
+{
+  "label": "mw6-before-2",
+  "timestamp": "2026-08-17T22:09:48.224Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 1000,
+    "dynamicRoutes": 100,
+    "middlewareCount": 6,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 8,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 97344,
+      "latency": 9.82
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 97824,
+      "latency": 9.76
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 96424,
+      "latency": 9.94
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 96464,
+      "latency": 9.94
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 97440,
+      "latency": 9.81
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 93592,
+      "latency": 10.22
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 96944,
+      "latency": 9.91
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 92384,
+      "latency": 10.32
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 94560,
+      "latency": 10.17
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 107592,
+      "latency": 8.9
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 106904,
+      "latency": 8.94
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 106440,
+      "latency": 8.94
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 106024,
+      "latency": 8.97
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 106864,
+      "latency": 8.94
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 106152,
+      "latency": 8.96
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 106424,
+      "latency": 8.94
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 105640,
+      "latency": 8.98
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 105888,
+      "latency": 8.98
+    }
+  ]
+}

--- a/benchmarks/results/router-tracing-mw6-before.json
+++ b/benchmarks/results/router-tracing-mw6-before.json
@@ -1,0 +1,129 @@
+{
+  "label": "mw6-before",
+  "timestamp": "2026-08-17T21:58:50.193Z",
+  "environment": {
+    "cpu": "Apple M4",
+    "memory": 34359738368,
+    "node": "v24.19.0",
+    "platform": "darwin 24.6.0 arm64"
+  },
+  "configuration": {
+    "staticRoutes": 1000,
+    "dynamicRoutes": 100,
+    "middlewareCount": 6,
+    "connections": 100,
+    "pipelining": 10,
+    "duration": 8,
+    "warmupDuration": 3
+  },
+  "results": [
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-first",
+      "requests": 97928,
+      "latency": 9.83
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "static-last",
+      "requests": 98600,
+      "latency": 9.72
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-first",
+      "requests": 97264,
+      "latency": 9.89
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "dynamic-last",
+      "requests": 97088,
+      "latency": 9.92
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-static",
+      "requests": 98056,
+      "latency": 9.81
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "alternating-dynamic",
+      "requests": 94376,
+      "latency": 10.1
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-static",
+      "requests": 97728,
+      "latency": 9.85
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-dynamic",
+      "requests": 92952,
+      "latency": 10.25
+    },
+    {
+      "framework": "AdonisJS HTTP Server",
+      "scenario": "varied-mixed",
+      "requests": 94664,
+      "latency": 10.12
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-first",
+      "requests": 107544,
+      "latency": 8.91
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "static-last",
+      "requests": 107000,
+      "latency": 8.93
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-first",
+      "requests": 104672,
+      "latency": 9.1
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "dynamic-last",
+      "requests": 106376,
+      "latency": 8.95
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-static",
+      "requests": 106432,
+      "latency": 8.94
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "alternating-dynamic",
+      "requests": 105816,
+      "latency": 8.98
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-static",
+      "requests": 106880,
+      "latency": 8.86
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-dynamic",
+      "requests": 106728,
+      "latency": 8.89
+    },
+    {
+      "framework": "Fastify",
+      "scenario": "varied-mixed",
+      "requests": 105832,
+      "latency": 8.96
+    }
+  ]
+}

--- a/benchmarks/router.js
+++ b/benchmarks/router.js
@@ -1,0 +1,204 @@
+/*
+ * @adonisjs/http-server
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { once } from 'node:events'
+import { arch, cpus, platform, release, totalmem } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fork } from 'node:child_process'
+import { mkdir, writeFile } from 'node:fs/promises'
+import autocannon from 'autocannon'
+
+const duration = Number(process.env.BENCH_DURATION ?? 10)
+const warmupDuration = Number(process.env.BENCH_WARMUP_DURATION ?? 3)
+const connections = Number(process.env.BENCH_CONNECTIONS ?? 100)
+const pipelining = Number(process.env.BENCH_PIPELINING ?? 10)
+const staticRoutes = Number(process.env.BENCH_STATIC_ROUTES ?? 1000)
+const dynamicRoutes = Number(process.env.BENCH_DYNAMIC_ROUTES ?? 100)
+const outputFile = process.env.BENCH_OUTPUT
+const label = process.env.BENCH_LABEL ?? 'unlabeled'
+
+/**
+ * Paths spread evenly over the whole table. A scenario built from a single path
+ * measures a repeated URL, which any per-URL memoisation answers without ever
+ * running the matcher, so these scenarios are the ones that show what real
+ * traffic pays.
+ */
+function spread(count, build) {
+  const total = Math.min(count, 25)
+  return Array.from({ length: total }, (_, index) => build(Math.floor((index * count) / total)))
+}
+
+const variedStatic = spread(staticRoutes, (index) => `/static/${index}`)
+const variedDynamic = spread(dynamicRoutes, (index) => `/dynamic/${index}/123`)
+
+const scenarios = [
+  { name: 'static-first', paths: ['/static/0'] },
+  { name: 'static-last', paths: [`/static/${staticRoutes - 1}`] },
+  { name: 'dynamic-first', paths: ['/dynamic/0/123'] },
+  { name: 'dynamic-last', paths: [`/dynamic/${dynamicRoutes - 1}/123`] },
+  { name: 'alternating-static', paths: ['/static/0', `/static/${staticRoutes - 1}`] },
+  { name: 'alternating-dynamic', paths: ['/dynamic/0/123', `/dynamic/${dynamicRoutes - 1}/123`] },
+  { name: 'varied-static', paths: variedStatic },
+  { name: 'varied-dynamic', paths: variedDynamic },
+  { name: 'varied-mixed', paths: variedStatic.flatMap((path, i) => [path, variedDynamic[i % variedDynamic.length]]) },
+]
+
+const frameworks = [
+  {
+    name: 'AdonisJS HTTP Server',
+    url: 'http://localhost:4001',
+    server: 'router_adonisjs.js',
+  },
+  { name: 'Fastify', url: 'http://localhost:3001', server: 'router_fastify.js' },
+]
+
+function runAutocannon(url, paths, seconds) {
+  return new Promise((resolve, reject) => {
+    autocannon(
+      {
+        url,
+        connections,
+        duration: seconds,
+        pipelining,
+        requests: paths.map((path) => ({ path })),
+      },
+      (error, result) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(result)
+        }
+      }
+    )
+  })
+}
+
+function startServer(file) {
+  return new Promise((resolve, reject) => {
+    const child = fork(join(import.meta.dirname, file), {
+      stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+    })
+    child.once('error', reject)
+    child.once('exit', (code, signal) => {
+      reject(new Error(`${file} exited before becoming ready (${code ?? signal})`))
+    })
+    child.once('message', () => resolve(child))
+  })
+}
+
+async function stopServer(child) {
+  if (child.exitCode === null) {
+    child.kill('SIGINT')
+    await once(child, 'exit')
+  }
+}
+
+async function verifyEndpoints(url) {
+  const paths = new Set(scenarios.flatMap((scenario) => scenario.paths))
+  for (const path of paths) {
+    const response = await fetch(`${url}${path}`)
+    if (!response.ok) {
+      throw new Error(`${url}${path} returned ${response.status}`)
+    }
+  }
+}
+
+async function runFramework(framework) {
+  console.log(`\n${framework.name}`)
+  const child = await startServer(framework.server)
+  try {
+    await verifyEndpoints(framework.url)
+    await runAutocannon(
+      framework.url,
+      scenarios.flatMap((scenario) => scenario.paths),
+      warmupDuration
+    )
+
+    const results = []
+    for (const scenario of scenarios) {
+      const result = await runAutocannon(framework.url, scenario.paths, duration)
+      if (result.errors || result.timeouts || result.non2xx) {
+        throw new Error(
+          `${framework.name} ${scenario.name} failed: ${result.errors} errors, ${result.timeouts} timeouts, ${result.non2xx} non-2xx responses`
+        )
+      }
+      results.push({
+        framework: framework.name,
+        scenario: scenario.name,
+        requests: result.requests.average,
+        latency: result.latency.average,
+      })
+      console.log(`${scenario.name}: ${Math.round(result.requests.average).toLocaleString()} req/s`)
+    }
+    return results
+  } finally {
+    await stopServer(child)
+  }
+}
+
+console.log(
+  `${staticRoutes} static routes + ${dynamicRoutes} dynamic routes | ${connections} connections | ${pipelining} pipelining | ${duration}s per scenario`
+)
+
+const results = []
+for (const framework of frameworks) {
+  results.push(...(await runFramework(framework)))
+}
+
+console.log('\nComparison')
+console.table(
+  scenarios.map((scenario) => {
+    const adonis = results.find(
+      (result) =>
+        result.framework === 'AdonisJS HTTP Server' && result.scenario === scenario.name
+    )
+    const fastify = results.find(
+      (result) => result.framework === 'Fastify' && result.scenario === scenario.name
+    )
+    return {
+      Scenario: scenario.name,
+      'AdonisJS req/s': Math.round(adonis.requests),
+      'Fastify req/s': Math.round(fastify.requests),
+      'AdonisJS vs Fastify': `${((adonis.requests / fastify.requests - 1) * 100).toFixed(2)}%`,
+      'AdonisJS latency': `${adonis.latency.toFixed(2)} ms`,
+      'Fastify latency': `${fastify.latency.toFixed(2)} ms`,
+    }
+  })
+)
+
+if (outputFile) {
+  await mkdir(dirname(outputFile), { recursive: true })
+  await writeFile(
+    outputFile,
+    `${JSON.stringify(
+      {
+        label,
+        timestamp: new Date().toISOString(),
+        environment: {
+          cpu: cpus()[0]?.model,
+          memory: totalmem(),
+          node: process.version,
+          platform: `${platform()} ${release()} ${arch()}`,
+        },
+        configuration: {
+          staticRoutes,
+          dynamicRoutes,
+          connections,
+          pipelining,
+          duration,
+          warmupDuration,
+        },
+        results,
+      },
+      null,
+      2
+    )}\n`
+  )
+  console.log(`Saved raw results to ${outputFile}`)
+}

--- a/benchmarks/router.js
+++ b/benchmarks/router.js
@@ -20,6 +20,7 @@ const connections = Number(process.env.BENCH_CONNECTIONS ?? 100)
 const pipelining = Number(process.env.BENCH_PIPELINING ?? 10)
 const staticRoutes = Number(process.env.BENCH_STATIC_ROUTES ?? 1000)
 const dynamicRoutes = Number(process.env.BENCH_DYNAMIC_ROUTES ?? 100)
+const middlewareCount = Number(process.env.BENCH_MIDDLEWARE_COUNT ?? 0)
 const outputFile = process.env.BENCH_OUTPUT
 const label = process.env.BENCH_LABEL ?? 'unlabeled'
 
@@ -143,7 +144,7 @@ async function runFramework(framework) {
 }
 
 console.log(
-  `${staticRoutes} static routes + ${dynamicRoutes} dynamic routes | ${connections} connections | ${pipelining} pipelining | ${duration}s per scenario`
+  `${staticRoutes} static routes + ${dynamicRoutes} dynamic routes | ${middlewareCount} middleware | ${connections} connections | ${pipelining} pipelining | ${duration}s per scenario`
 )
 
 const results = []
@@ -189,6 +190,7 @@ if (outputFile) {
         configuration: {
           staticRoutes,
           dynamicRoutes,
+          middlewareCount,
           connections,
           pipelining,
           duration,

--- a/benchmarks/router_adonisjs.js
+++ b/benchmarks/router_adonisjs.js
@@ -1,0 +1,76 @@
+/*
+ * @adonisjs/http-server
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { createServer } from 'node:http'
+import { Logger } from '@adonisjs/logger'
+import { Emitter } from '@adonisjs/events'
+import { EncryptionFactory } from '@boringnode/encryption/factories'
+import { Application } from '@adonisjs/application'
+
+import { defineConfig, Server } from '../build/index.js'
+
+const staticRoutes = Number(process.env.BENCH_STATIC_ROUTES ?? 1000)
+const dynamicRoutes = Number(process.env.BENCH_DYNAMIC_ROUTES ?? 100)
+const shape = process.env.BENCH_SHAPE ?? 'uniform'
+
+const app = new Application(new URL('./', import.meta.url), {
+  environment: 'web',
+  importer: () => {},
+})
+await app.init()
+
+const server = new Server(
+  app,
+  new EncryptionFactory().create(),
+  new Emitter(app),
+  new Logger({ enabled: false }),
+  defineConfig({
+    serializeJSON(value) {
+      return JSON.stringify(value)
+    },
+  })
+)
+const router = server.getRouter()
+const handler = (ctx) => ctx.response.send({ hello: 'world' })
+
+/**
+ * The `uniform` shape declares every static route before any dynamic one and
+ * has no catch-all. The `app` shape mirrors how routes accumulate in a real
+ * application: a dynamic route appears early among the static ones, and a top
+ * level param route plus a catch-all close the file. Both shapes resolve the
+ * benchmark URLs to the same routes, because the trailing routes only capture
+ * URLs nothing else matches.
+ */
+if (shape === 'app') {
+  for (let index = 0; index < 5; index++) {
+    router.get(`/static/${index}`, handler)
+  }
+  router.get('/dynamic/early/:id', handler)
+  for (let index = 5; index < staticRoutes; index++) {
+    router.get(`/static/${index}`, handler)
+  }
+  for (let index = 0; index < dynamicRoutes; index++) {
+    router.get(`/dynamic/${index}/:id`, handler)
+  }
+  router.get('/:section', handler)
+  router.get('/:section/*', handler)
+} else {
+  for (let index = 0; index < staticRoutes; index++) {
+    router.get(`/static/${index}`, handler)
+  }
+  for (let index = 0; index < dynamicRoutes; index++) {
+    router.get(`/dynamic/${index}/:id`, handler)
+  }
+}
+
+await server.boot()
+
+createServer(server.handle.bind(server)).listen(4001, () => {
+  process.send?.('ready')
+})

--- a/benchmarks/router_adonisjs.js
+++ b/benchmarks/router_adonisjs.js
@@ -18,6 +18,7 @@ import { defineConfig, Server } from '../build/index.js'
 const staticRoutes = Number(process.env.BENCH_STATIC_ROUTES ?? 1000)
 const dynamicRoutes = Number(process.env.BENCH_DYNAMIC_ROUTES ?? 100)
 const shape = process.env.BENCH_SHAPE ?? 'uniform'
+const middlewareCount = Number(process.env.BENCH_MIDDLEWARE_COUNT ?? 0)
 
 const app = new Application(new URL('./', import.meta.url), {
   environment: 'web',
@@ -38,6 +39,35 @@ const server = new Server(
 )
 const router = server.getRouter()
 const handler = (ctx) => ctx.response.send({ hello: 'world' })
+/**
+ * A middleware that does nothing measures the instrumentation around it and
+ * little else, which overstates what removing that instrumentation is worth.
+ * `BENCH_MIDDLEWARE_KIND=realistic` swaps in one that awaits, reads a header
+ * and allocates, which is still less work than session, auth or CSRF
+ * middleware perform.
+ */
+class NoopMiddleware {
+  handle(_, next) {
+    return next()
+  }
+}
+
+class RealisticMiddleware {
+  async handle(ctx, next) {
+    const userAgent = ctx.request.request.headers['user-agent'] || ''
+    const meta = { length: userAgent.length, secure: ctx.request.request.socket.encrypted === true }
+    if (meta.length < 0) {
+      throw new Error('unreachable')
+    }
+    return next()
+  }
+}
+
+const MiddlewareClass =
+  process.env.BENCH_MIDDLEWARE_KIND === 'realistic' ? RealisticMiddleware : NoopMiddleware
+const loadMiddleware = async () => ({ default: MiddlewareClass })
+
+server.use(Array.from({ length: middlewareCount }, () => loadMiddleware))
 
 /**
  * The `uniform` shape declares every static route before any dynamic one and

--- a/benchmarks/router_fastify.js
+++ b/benchmarks/router_fastify.js
@@ -13,10 +13,31 @@ import middie from '@fastify/middie'
 const staticRoutes = Number(process.env.BENCH_STATIC_ROUTES ?? 1000)
 const dynamicRoutes = Number(process.env.BENCH_DYNAMIC_ROUTES ?? 100)
 const shape = process.env.BENCH_SHAPE ?? 'uniform'
+const middlewareCount = Number(process.env.BENCH_MIDDLEWARE_COUNT ?? 0)
 const app = fastify()
 const handler = (_, reply) => reply.send({ hello: 'world' })
 
 await app.register(middie.default)
+
+/**
+ * Mirror of the middleware registered by the AdonisJS server, so both sides run
+ * comparable work. See `BENCH_MIDDLEWARE_KIND` there.
+ */
+const middleware =
+  process.env.BENCH_MIDDLEWARE_KIND === 'realistic'
+    ? async (req, _, next) => {
+        const userAgent = req.headers['user-agent'] || ''
+        const meta = { length: userAgent.length, secure: req.socket.encrypted === true }
+        if (meta.length < 0) {
+          throw new Error('unreachable')
+        }
+        next()
+      }
+    : (_, __, next) => next()
+
+for (let index = 0; index < middlewareCount; index++) {
+  app.use(middleware)
+}
 
 for (let index = 0; index < staticRoutes; index++) {
   app.get(`/static/${index}`, handler)

--- a/benchmarks/router_fastify.js
+++ b/benchmarks/router_fastify.js
@@ -1,0 +1,41 @@
+/*
+ * @adonisjs/http-server
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { fastify } from 'fastify'
+import middie from '@fastify/middie'
+
+const staticRoutes = Number(process.env.BENCH_STATIC_ROUTES ?? 1000)
+const dynamicRoutes = Number(process.env.BENCH_DYNAMIC_ROUTES ?? 100)
+const shape = process.env.BENCH_SHAPE ?? 'uniform'
+const app = fastify()
+const handler = (_, reply) => reply.send({ hello: 'world' })
+
+await app.register(middie.default)
+
+for (let index = 0; index < staticRoutes; index++) {
+  app.get(`/static/${index}`, handler)
+}
+for (let index = 0; index < dynamicRoutes; index++) {
+  app.get(`/dynamic/${index}/:id`, handler)
+}
+
+/**
+ * Mirror of the `app` shape registered by the AdonisJS server, so both control
+ * and subject serve the same route table. Fastify resolves by specificity
+ * rather than registration order, so the declaration position of these routes
+ * does not matter here.
+ */
+if (shape === 'app') {
+  app.get('/dynamic/early/:id', handler)
+  app.get('/:section', handler)
+  app.get('/:section/*', handler)
+}
+
+await app.listen({ port: 3001 })
+process.send?.('ready')

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "build": "npm run compile",
     "prebenchmark": "npm run build",
     "benchmark": "node benchmarks/index.js",
+    "prebenchmark:router": "npm run build",
+    "benchmark:router": "node benchmarks/router.js",
     "release": "release-it",
     "version": "npm run build",
     "format": "prettier --write .",

--- a/src/response.ts
+++ b/src/response.ts
@@ -1204,7 +1204,11 @@ export class HttpResponse extends Macroable {
      * Handle text based response
      */
     if (this.content) {
-      httpResponseSerializer.traceSync(this.writeBody, undefined, this, ...this.content)
+      if (httpResponseSerializer.hasSubscribers) {
+        httpResponseSerializer.traceSync(this.writeBody, undefined, this, ...this.content)
+      } else {
+        this.writeBody(...this.content)
+      }
       return
     }
 

--- a/src/router/executor.ts
+++ b/src/router/executor.ts
@@ -35,44 +35,46 @@ export function execute(
     .finalHandler(() => {
       if (typeof route.handler === 'function') {
         return (
-          httpRouteHandler.tracePromise(
-            ($ctx: HttpContext) => Promise.resolve((route.handler as Function)($ctx)),
-            httpRouteHandler.hasSubscribers ? { route } : undefined,
-            undefined,
-            ctx
-          ) as unknown as Promise<any>
+          httpRouteHandler.hasSubscribers
+            ? httpRouteHandler.tracePromise(
+                ($ctx: HttpContext) => Promise.resolve((route.handler as Function)($ctx)),
+                { route },
+                undefined,
+                ctx
+              )
+            : Promise.resolve(route.handler(ctx))
         ).then(useReturnValue(ctx))
       }
 
       return (
-        httpRouteHandler.tracePromise(
-          route.handler.handle,
-          httpRouteHandler.hasSubscribers ? { route } : undefined,
-          undefined,
-          resolver,
-          ctx
-        ) as unknown as Promise<any>
+        httpRouteHandler.hasSubscribers
+          ? httpRouteHandler.tracePromise(route.handler.handle, { route }, undefined, resolver, ctx)
+          : Promise.resolve(route.handler.handle(resolver, ctx))
       ).then(useReturnValue(ctx))
     })
     .run(async (middleware, next) => {
       if (typeof middleware === 'function') {
-        return httpMiddleware.tracePromise(
-          middleware,
-          httpMiddleware.hasSubscribers ? { middleware } : undefined,
-          undefined,
-          ctx,
-          next
-        ) as unknown as Promise<any>
+        return httpMiddleware.hasSubscribers
+          ? (httpMiddleware.tracePromise(
+              middleware,
+              { middleware },
+              undefined,
+              ctx,
+              next
+            ) as unknown as Promise<any>)
+          : middleware(ctx, next)
       }
 
-      return httpMiddleware.tracePromise(
-        middleware.handle,
-        httpMiddleware.hasSubscribers ? { middleware } : undefined,
-        undefined,
-        resolver,
-        ctx,
-        next,
-        middleware.args
-      ) as unknown as Promise<any>
+      return httpMiddleware.hasSubscribers
+        ? (httpMiddleware.tracePromise(
+            middleware.handle,
+            { middleware },
+            undefined,
+            resolver,
+            ctx,
+            next,
+            middleware.args
+          ) as unknown as Promise<any>)
+        : middleware.handle(resolver, ctx, next, middleware.args)
     })
 }

--- a/src/router/store.ts
+++ b/src/router/store.ts
@@ -15,12 +15,19 @@ import type {
   RouteJSON,
   MatchedRoute,
   StoreDomainNode,
-  StoreMethodNode,
   StoreRoutesTree,
   MatchItRouteToken,
+  IndexedStoreMethodNode,
 } from '../types/route.ts'
 import debug from '../debug.ts'
 import { parseRoute } from '../helpers.ts'
+
+/**
+ * Number of routes registered for a single domain and method below which route
+ * matching scans every token array instead of consulting the static prefix
+ * index. See `#matchRoute`.
+ */
+const SMALL_TABLE_ROUTES = 64
 
 /**
  * Store class is used to store a list of routes, along side with their tokens
@@ -70,13 +77,118 @@ export class RoutesStore {
   /**
    * Returns the method node for a given domain and method.
    */
-  #getMethodNode(domain: string, method: string): StoreMethodNode {
+  #getMethodNode(domain: string, method: string): IndexedStoreMethodNode {
     const domainNode = this.#getDomainNode(domain)
     if (!domainNode[method]) {
-      domainNode[method] = { tokens: [], routes: {}, routeKeys: {} }
+      domainNode[method] = {
+        tokens: [],
+        routesByStaticPrefix: null,
+        routesWithoutStaticPrefix: [],
+        tokenIndexes: new Map(),
+        shadowTokens: [],
+        routes: {},
+        routeKeys: {},
+        lastUrl: null,
+        lastTokens: [],
+        lastRoute: null,
+        lastRouteKey: '',
+        lastHasParams: false,
+        staticRoutes: null,
+      } satisfies IndexedStoreMethodNode
     }
 
-    return domainNode[method]
+    return domainNode[method] as IndexedStoreMethodNode
+  }
+
+  /**
+   * Narrows route matching to patterns sharing the URL's leading static segments.
+   *
+   * Every group is kept in registration order, and `matchit.match` returns the
+   * first entry of a group that matches. Therefore matching each group on its
+   * own and keeping the winner with the lowest registration index selects the
+   * same route as matching the merged groups in registration order, without
+   * having to build and sort a merged array on every request.
+   */
+  #matchRoute(url: string, methodRoutes: IndexedStoreMethodNode): MatchItRouteToken[] {
+    /**
+     * Narrowing has a fixed cost per request: slicing the path at every segment
+     * boundary and looking each slice up. Below a small number of routes a plain
+     * scan over every token array is cheaper than that bookkeeping, so the index
+     * is only consulted once the table is large enough to pay for it.
+     */
+    if (methodRoutes.tokens.length <= SMALL_TABLE_ROUTES) {
+      return matchit.match(url, methodRoutes.tokens)
+    }
+
+    let path = url
+    if (path !== '/') {
+      if (path.charCodeAt(0) === 47) {
+        path = path.substring(1)
+      }
+      if (path.charCodeAt(path.length - 1) === 47) {
+        path = path.substring(0, path.length - 1)
+      }
+    }
+
+    const routesByStaticPrefix = methodRoutes.routesByStaticPrefix
+    let matched: MatchItRouteToken[] | undefined
+    let matchedIndex = 0
+    let matchedIndexResolved = false
+    let consultedGroup = false
+
+    if (routesByStaticPrefix) {
+      for (let index = 1; index <= path.length; index++) {
+        if (index !== path.length && path.charCodeAt(index) !== 47) {
+          continue
+        }
+
+        const prefixCandidates = routesByStaticPrefix[path.substring(0, index)]
+        if (!prefixCandidates) {
+          continue
+        }
+
+        consultedGroup = true
+        const prefixMatch = matchit.match(url, prefixCandidates)
+        if (!prefixMatch.length) {
+          continue
+        }
+
+        /**
+         * The first match wins until a second group also matches, at which
+         * point registration indexes decide. Resolving them lazily keeps the
+         * common single-group case free of map lookups.
+         */
+        if (!matched) {
+          matched = prefixMatch
+          continue
+        }
+
+        if (!matchedIndexResolved) {
+          matchedIndex = methodRoutes.tokenIndexes.get(matched)!
+          matchedIndexResolved = true
+        }
+
+        const prefixMatchIndex = methodRoutes.tokenIndexes.get(prefixMatch)!
+        if (prefixMatchIndex < matchedIndex) {
+          matched = prefixMatch
+          matchedIndex = prefixMatchIndex
+        }
+      }
+    }
+
+    /**
+     * Every prefix group already carries the routes without a static prefix, so
+     * consulting a single group covers them too. They are only matched on their
+     * own when the url shares no leading static segment with any group.
+     */
+    if (!consultedGroup) {
+      const routesWithoutStaticPrefix = methodRoutes.routesWithoutStaticPrefix
+      if (routesWithoutStaticPrefix.length) {
+        return matchit.match(url, routesWithoutStaticPrefix)
+      }
+    }
+
+    return matched ?? []
   }
 
   /**
@@ -121,10 +233,84 @@ export class RoutesStore {
       debug('route middleware %O', route.middleware.all().entries())
     }
 
+    const routeKey =
+      domain !== 'root' ? `${domain}-${method}-${route.pattern}` : `${method}-${route.pattern}`
+    const tokenIndex = methodRoutes.tokens.length
+    methodRoutes.tokenIndexes.set(tokens, tokenIndex)
     methodRoutes.tokens.push(tokens)
     methodRoutes.routes[route.pattern] = route
-    methodRoutes.routeKeys[route.pattern] =
-      domain !== 'root' ? `${domain}-${method}-${route.pattern}` : `${method}-${route.pattern}`
+    methodRoutes.routeKeys[route.pattern] = routeKey
+    this.#resetLastMatch(methodRoutes)
+
+    let staticPrefix = ''
+    if (tokens[0]?.type === 0 && tokens[0].val) {
+      for (const token of tokens) {
+        if (token.type !== 0) {
+          break
+        }
+        staticPrefix = staticPrefix ? `${staticPrefix}/${token.val}` : token.val
+      }
+    }
+
+    /**
+     * Routes without a static prefix can match any url, so every prefix group
+     * has to consider them. They are merged into the groups here rather than
+     * matched separately on every request. Routes are always appended with the
+     * highest registration index so far, so both branches keep every group in
+     * registration order, which is the order `matchit` resolves by.
+     */
+    if (staticPrefix) {
+      const routesByStaticPrefix = (methodRoutes.routesByStaticPrefix ??= Object.create(null))
+      const prefixRoutes = (routesByStaticPrefix[staticPrefix] ??= [
+        ...methodRoutes.routesWithoutStaticPrefix,
+      ])
+      prefixRoutes.push(tokens)
+    } else {
+      methodRoutes.routesWithoutStaticPrefix.push(tokens)
+      const routesByStaticPrefix = methodRoutes.routesByStaticPrefix
+      if (routesByStaticPrefix) {
+        for (const prefix of Object.keys(routesByStaticPrefix)) {
+          routesByStaticPrefix[prefix].push(tokens)
+        }
+      }
+    }
+
+    /**
+     * A route can join the exact lookup table when its pattern is spelled the
+     * same way a matching URL is, it has no dynamic segments, and no earlier
+     * route matches it. `matchit` returns the first registered match, so a
+     * later route can never take precedence over this one.
+     *
+     * Only routes tracked in `shadowTokens` can shadow a static pattern: two
+     * canonical static patterns match the same URL only when the patterns are
+     * identical, which the duplicate check above already rejects.
+     */
+    const isCanonical =
+      route.pattern === '/' ||
+      (route.pattern.charCodeAt(0) === 47 &&
+        route.pattern.charCodeAt(route.pattern.length - 1) !== 47)
+    const isStatic = tokens.length > 0 && tokens.every((token) => token.type === 0)
+
+    if (isCanonical && isStatic) {
+      if (!matchit.match(route.pattern, methodRoutes.shadowTokens).length) {
+        const staticRoutes = (methodRoutes.staticRoutes ??= Object.create(null))
+        staticRoutes[route.pattern] = { tokens, route, routeKey }
+      }
+    } else {
+      methodRoutes.shadowTokens.push(tokens)
+    }
+  }
+
+  /**
+   * Clears the memo of the last matched URL. Called whenever a registration
+   * invalidates what the node previously resolved.
+   */
+  #resetLastMatch(methodRoutes: IndexedStoreMethodNode) {
+    methodRoutes.lastUrl = null
+    methodRoutes.lastTokens = []
+    methodRoutes.lastRoute = null
+    methodRoutes.lastRouteKey = ''
+    methodRoutes.lastHasParams = false
   }
 
   /**
@@ -203,7 +389,7 @@ export class RoutesStore {
      * method node is missing, means no routes ever got registered for that
      * method
      */
-    const matchedMethod = this.tree.domains[domainName][method]
+    const matchedMethod = this.tree.domains[domainName][method] as IndexedStoreMethodNode
     if (!matchedMethod) {
       return null
     }
@@ -212,16 +398,37 @@ export class RoutesStore {
      * Next, match route for the given url inside the tokens list for the
      * matchedMethod
      */
-    const matchedRoute = matchit.match(url, matchedMethod.tokens)
-    if (!matchedRoute.length) {
+    let matchedRoute = matchedMethod.lastTokens
+    let route = matchedMethod.lastRoute
+    let routeKey = matchedMethod.lastRouteKey
+    let hasParams = matchedMethod.lastHasParams
+
+    if (matchedMethod.lastUrl !== url) {
+      const staticRoute = matchedMethod.staticRoutes?.[url]
+      matchedRoute = staticRoute?.tokens ?? this.#matchRoute(url, matchedMethod)
+
+      if (!matchedRoute.length) {
+        this.#resetLastMatch(matchedMethod)
+        matchedMethod.lastUrl = url
+        return null
+      }
+
+      route = staticRoute?.route ?? matchedMethod.routes[matchedRoute[0].old]
+      routeKey = staticRoute?.routeKey ?? matchedMethod.routeKeys[route.pattern]
+      hasParams = staticRoute ? false : matchedRoute.some((token) => token.type !== 0)
+      matchedMethod.lastUrl = url
+      matchedMethod.lastTokens = matchedRoute
+      matchedMethod.lastRoute = route
+      matchedMethod.lastRouteKey = routeKey
+      matchedMethod.lastHasParams = hasParams
+    } else if (!route) {
       return null
     }
 
-    const route = matchedMethod.routes[matchedRoute[0].old]
     return {
-      route: route,
-      routeKey: matchedMethod.routeKeys[route.pattern],
-      params: matchit.exec(url, matchedRoute, shouldDecodeParam),
+      route,
+      routeKey,
+      params: hasParams ? matchit.exec(url, matchedRoute, shouldDecodeParam) : {},
       subdomains: domain?.hostname ? matchit.exec(domain.hostname, domain.tokens) : {},
     }
   }

--- a/src/server/factories/middleware_handler.ts
+++ b/src/server/factories/middleware_handler.ts
@@ -37,13 +37,8 @@ export function middlewareHandler(resolver: ContainerResolver<any>, ctx: HttpCon
    */
   return function (fn: ParsedGlobalMiddleware, next: NextFn) {
     debug('executing middleware %s', fn.name)
-    return httpMiddleware.tracePromise(
-      fn.handle,
-      httpMiddleware.hasSubscribers ? { middleware: fn } : undefined,
-      undefined,
-      resolver,
-      ctx,
-      next
-    ) as unknown as Promise<any>
+    return (httpMiddleware.hasSubscribers
+      ? httpMiddleware.tracePromise(fn.handle, { middleware: fn }, undefined, resolver, ctx, next)
+      : fn.handle(resolver, ctx, next)) as unknown as Promise<any>
   }
 }

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -139,13 +139,15 @@ export class Server {
   #requestErrorResponder: ServerErrorHandler['handle'] = async (error, ctx) => {
     await this.#resolvedErrorHandler.report(error, ctx)
 
-    return httpExceptionHandler.tracePromise(
-      this.#resolvedErrorHandler.handle,
-      undefined,
-      this.#resolvedErrorHandler,
-      error,
-      ctx
-    )
+    return httpExceptionHandler.hasSubscribers
+      ? httpExceptionHandler.tracePromise(
+          this.#resolvedErrorHandler.handle,
+          undefined,
+          this.#resolvedErrorHandler,
+          error,
+          ctx
+        )
+      : this.#resolvedErrorHandler.handle(error, ctx)
   }
 
   /**
@@ -472,22 +474,14 @@ export class Server {
      */
     if (this.usingAsyncLocalStorage) {
       return asyncLocalStorage.storage!.run(ctx, () =>
-        httpRequest.tracePromise(
-          this.#handleRequest,
-          httpRequest.hasSubscribers ? { ctx } : undefined,
-          this,
-          ctx,
-          resolver
-        )
+        httpRequest.hasSubscribers
+          ? httpRequest.tracePromise(this.#handleRequest, { ctx }, this, ctx, resolver)
+          : this.#handleRequest(ctx, resolver)
       )
     }
 
-    return httpRequest.tracePromise(
-      this.#handleRequest,
-      httpRequest.hasSubscribers ? { ctx } : undefined,
-      this,
-      ctx,
-      resolver
-    )
+    return httpRequest.hasSubscribers
+      ? httpRequest.tracePromise(this.#handleRequest, { ctx }, this, ctx, resolver)
+      : this.#handleRequest(ctx, resolver)
   }
 }

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -89,7 +89,65 @@ export type StoreMethodNode = {
   routes: {
     [pattern: string]: RouteJSON
   }
+
+  /*
+   * The following properties are matching indexes maintained by the store. They
+   * are optional so that the published shape of this type stays compatible for
+   * code constructing a method node by hand.
+   */
+
+  /** Routes grouped by their leading static path segments */
+  routesByStaticPrefix?: null | Record<string, MatchItRouteToken[][]>
+  /** Routes whose first path segment is dynamic */
+  routesWithoutStaticPrefix?: MatchItRouteToken[][]
+  /** Registration position for each token array */
+  tokenIndexes?: Map<MatchItRouteToken[], number>
+  /**
+   * Tokens of earlier routes that are able to shadow a static route. Used to
+   * decide whether a static route may join the exact lookup table.
+   */
+  shadowTokens?: MatchItRouteToken[][]
+  /** Last URL matched by this method node. `null` when the memo is empty */
+  lastUrl?: string | null
+  /** Tokens selected for the last matched URL */
+  lastTokens?: MatchItRouteToken[]
+  /** Route selected for the last matched URL */
+  lastRoute?: RouteJSON | null
+  /** Unique key for the last matched route */
+  lastRouteKey?: string
+  /** Whether the last matched route contains dynamic parameters */
+  lastHasParams?: boolean
+  /** Exact lookup table for static routes that cannot be shadowed by earlier routes */
+  staticRoutes?: null | Record<
+    string,
+    {
+      tokens: MatchItRouteToken[]
+      route: RouteJSON
+      routeKey: string
+    }
+  >
 }
+
+/**
+ * Method node with the store maintained matching indexes always present. Used
+ * internally by the store, which is the only writer of these properties.
+ */
+export type IndexedStoreMethodNode = StoreMethodNode &
+  Required<
+    Pick<
+      StoreMethodNode,
+      | 'routesByStaticPrefix'
+      | 'routesWithoutStaticPrefix'
+      | 'tokenIndexes'
+      | 'shadowTokens'
+      | 'lastUrl'
+      | 'lastTokens'
+      | 'lastRoute'
+      | 'lastRouteKey'
+      | 'lastHasParams'
+      | 'staticRoutes'
+    >
+  >
 
 /**
  * Domain-specific route storage containing method-based route organization

--- a/tests/router/store.spec.ts
+++ b/tests/router/store.spec.ts
@@ -14,6 +14,20 @@ import { parseRoute } from '../../src/helpers.ts'
 import { execute } from '../../src/router/executor.ts'
 import { RoutesStore } from '../../src/router/store.ts'
 
+function addRoute(store: RoutesStore, pattern: string) {
+  store.add({
+    pattern,
+    tokens: parseRoute(pattern),
+    handler() {},
+    matchers: {},
+    meta: {},
+    execute,
+    middleware: new Middleware<any>(),
+    methods: ['GET'],
+    domain: 'root',
+  })
+}
+
 test.group('Store | add', () => {
   test('add route without explicit domain', ({ assert }) => {
     async function handler() {}
@@ -556,6 +570,21 @@ test.group('Store | add', () => {
 })
 
 test.group('Store | match', () => {
+  test('invalidate the last match when adding a route', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/health')
+    assert.isNull(store.match('/users/1', 'GET', false))
+    addRoute(store, '/users/:id')
+    assert.equal(store.match('/users/1', 'GET', false)?.params.id, '1')
+  })
+
+  test('decode params when reusing the last route match', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/users/:id')
+    assert.equal(store.match('/users/hello%20world', 'GET', false)?.params.id, 'hello%20world')
+    assert.equal(store.match('/users/hello%20world', 'GET', true)?.params.id, 'hello world')
+  })
+
   test('find route for a given url', ({ assert }) => {
     async function handler() {}
 
@@ -710,6 +739,114 @@ test.group('Store | match', () => {
       subdomains: {},
       routeKey: 'GET-/:username',
     })
+  })
+
+  test('do not let the static index shadow an earlier dynamic route', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/:username')
+    addRoute(store, '/virk')
+    assert.equal(store.match('/virk', 'GET', false)?.route.pattern, '/:username')
+    assert.equal(store.match('/virk', 'GET', false)?.params.username, 'virk')
+  })
+
+  test('preserve registration order across static prefix groups', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/users/:id')
+    addRoute(store, '/users/admin')
+    assert.equal(store.match('/users/admin', 'GET', false)?.route.pattern, '/users/:id')
+  })
+
+  test('preserve registration order for routes without a static prefix', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/:section/admin')
+    addRoute(store, '/users/:id')
+    assert.equal(store.match('/users/admin', 'GET', false)?.route.pattern, '/:section/admin')
+  })
+
+  test('match optional and wildcard routes through the static prefix index', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/users/:id?')
+    addRoute(store, '/files/*')
+    assert.equal(store.match('/users', 'GET', false)?.route.pattern, '/users/:id?')
+    assert.equal(store.match('/files/a/b', 'GET', false)?.route.pattern, '/files/*')
+  })
+
+  test('index static routes registered after a dynamic route', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/users/:id')
+    addRoute(store, '/health')
+    addRoute(store, '/metrics')
+
+    /**
+     * A dynamic route registered first must not keep later static routes out of
+     * the exact lookup table. Only routes that actually shadow them may.
+     */
+    assert.deepEqual(Object.keys(store.tree.domains.root.GET.staticRoutes ?? {}), [
+      '/health',
+      '/metrics',
+    ])
+
+    assert.equal(store.match('/health', 'GET', false)?.route.pattern, '/health')
+    assert.equal(store.match('/metrics', 'GET', false)?.route.pattern, '/metrics')
+    assert.equal(store.match('/users/1', 'GET', false)?.params.id, '1')
+  })
+
+  test('keep matching static routes that an earlier route shadows', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/*')
+    addRoute(store, '/health')
+
+    assert.deepEqual(Object.keys(store.tree.domains.root.GET.staticRoutes ?? {}), [])
+    assert.equal(store.match('/health', 'GET', false)?.route.pattern, '/*')
+    assert.deepEqual(store.match('/health', 'GET', false)?.params, { '*': ['health'] })
+  })
+
+  test('do not let a trailing slash pattern shadow the static index', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/health/')
+    addRoute(store, '/health')
+
+    assert.deepEqual(Object.keys(store.tree.domains.root.GET.staticRoutes ?? {}), [])
+    assert.equal(store.match('/health', 'GET', false)?.route.pattern, '/health/')
+  })
+
+  test('return null for a repeated non matching url', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/users/:id')
+
+    assert.isNull(store.match('/nope', 'GET', false))
+    assert.isNull(store.match('/nope', 'GET', false))
+  })
+
+  test('do not resurrect the last route after adding a route', ({ assert }) => {
+    const store = new RoutesStore()
+    addRoute(store, '/users/:id')
+    assert.equal(store.match('/users/7', 'GET', false)?.route.pattern, '/users/:id')
+
+    addRoute(store, '/health')
+
+    /**
+     * Registration clears the memo of the last match. No url may resolve to the
+     * previously matched route just because the memo was invalidated.
+     */
+    assert.isNull(store.match('\0', 'GET', false))
+    assert.isNull(store.match('', 'GET', false))
+    assert.equal(store.match('/users/7', 'GET', false)?.route.pattern, '/users/:id')
+  })
+
+  test('match routes past the small table threshold', ({ assert }) => {
+    const store = new RoutesStore()
+    for (let index = 0; index < 120; index++) {
+      addRoute(store, `/static/${index}`)
+    }
+    for (let index = 0; index < 120; index++) {
+      addRoute(store, `/dynamic/${index}/:id`)
+    }
+
+    assert.equal(store.match('/static/0', 'GET', false)?.route.pattern, '/static/0')
+    assert.equal(store.match('/static/119', 'GET', false)?.route.pattern, '/static/119')
+    assert.equal(store.match('/dynamic/119/7', 'GET', false)?.params.id, '7')
+    assert.isNull(store.match('/static/120', 'GET', false))
   })
 
   test('test params against matchers before matching', ({ assert }) => {

--- a/tests/tracing_channels.spec.ts
+++ b/tests/tracing_channels.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * @adonisjs/http-server
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import supertest from 'supertest'
+import { test } from '@japa/runner'
+import type { NextFn } from '@poppinss/middleware/types'
+import { AppFactory } from '@adonisjs/application/factories'
+import { createServer } from 'node:http'
+
+import type { HttpContext } from '../src/http_context/main.ts'
+import { ServerFactory } from '../factories/server_factory.ts'
+import {
+  httpRequest,
+  httpMiddleware,
+  httpRouteHandler,
+  httpExceptionHandler,
+  httpResponseSerializer,
+} from '../src/tracing_channels.ts'
+
+const BASE_URL = new URL('./app/', import.meta.url)
+
+test('emit tracing events when channels have subscribers', async ({ assert }) => {
+  const events: string[] = []
+  const createHandlers = (name: string) => ({
+    start() {
+      events.push(name)
+    },
+    end() {},
+    asyncStart() {},
+    asyncEnd() {},
+    error() {},
+  })
+  const requestHandlers = createHandlers('request')
+  const middlewareHandlers = createHandlers('middleware')
+  const routeHandlers = createHandlers('route')
+  const exceptionHandlers = createHandlers('exception')
+  const responseHandlers = createHandlers('response')
+
+  httpRequest.subscribe(requestHandlers)
+  httpMiddleware.subscribe(middlewareHandlers)
+  httpRouteHandler.subscribe(routeHandlers)
+  httpExceptionHandler.subscribe(exceptionHandlers)
+  httpResponseSerializer.subscribe(responseHandlers)
+
+  try {
+    const app = new AppFactory().create(BASE_URL, () => {})
+    const server = new ServerFactory().merge({ app }).create()
+    const httpServer = createServer(server.handle.bind(server))
+
+    await app.init()
+    server.use([
+      async () => ({
+        default: class GlobalMiddleware {
+          handle(_: HttpContext, next: NextFn) {
+            return next()
+          }
+        },
+      }),
+    ])
+    server
+      .getRouter()
+      .get('/', () => ({ hello: 'world' }))
+      .middleware((_, next) => next())
+    await server.boot()
+
+    await supertest(httpServer).get('/').expect(200).expect({ hello: 'world' })
+    await supertest(httpServer).get('/missing').expect(404)
+
+    assert.deepEqual(events, [
+      'request',
+      'middleware',
+      'middleware',
+      'route',
+      'response',
+      'request',
+      'middleware',
+      'exception',
+      'response',
+    ])
+  } finally {
+    httpRequest.unsubscribe(requestHandlers)
+    httpMiddleware.unsubscribe(middlewareHandlers)
+    httpRouteHandler.unsubscribe(routeHandlers)
+    httpExceptionHandler.unsubscribe(exceptionHandlers)
+    httpResponseSerializer.unsubscribe(responseHandlers)
+  }
+})


### PR DESCRIPTION
> Stacked on #135. The first three commits belong to that pull request; only the last two are new here. Reviewing `perf(server): skip tracing without subscribers` and `docs: record tracing benchmark results` is enough, and this will be rebased once #135 lands.

## The problem

Request handlers, middleware, response serialization and the exception handler each run inside a `diagnostics_channel` tracing wrapper:

```ts
httpMiddleware.tracePromise(
  middleware,
  httpMiddleware.hasSubscribers ? { middleware } : undefined,
  undefined,
  ctx,
  next
)
```

`tracePromise` publishes to the start channel, attaches continuations to the returned promise, and publishes again on settle. That happens on every one of those call sites on every request, whether or not anything is subscribed. With no subscriber the published events go nowhere and the continuations exist only to publish them.

A request passes through one of these per middleware, plus one for the request, the route handler and the serializer, so the cost is paid roughly two dozen times in an application with a normal middleware stack. Nothing observes it unless an APM or a `diagnostics_channel` subscriber is attached, which is not the default.

## The change

Call the target directly when the channel reports no subscribers:

```ts
httpMiddleware.hasSubscribers
  ? httpMiddleware.tracePromise(middleware, { middleware }, undefined, ctx, next)
  : middleware(ctx, next)
```

The traced path is untouched, so subscribers see exactly the events they saw before, in the same order. `hasSubscribers` was already read on each of these calls to decide the context argument, so the check itself is not new work. Applied to the five call sites in `executor.ts`, `middleware_handler.ts`, `server/main.ts` and `response.ts`.

A test asserts the full event sequence with subscribers attached, covering both a successful request and one that ends in the exception handler.

## The numbers

Measured with `BENCH_MIDDLEWARE_KIND=realistic`, added here. The benchmark previously registered middleware that only returns `next()`; against that, the tracing wrapper is close to the entire cost of a middleware and the result looks better than it is. The realistic middleware awaits, reads a header and allocates, which is still less than session, auth or CSRF middleware do. Both servers register the same middleware and Fastify is reported as a control.

Averages across nine scenarios, 8 seconds each:

| Middleware | before | after | Raw | Fastify control | Control-adjusted |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 20 | 55,626 | 56,508 | +1.59% | −0.00% | **+1.59%** |
| 6, run 1 | 96,517 | 97,090 | +0.59% | +1.50% | −0.91% |
| 6, run 2 | 95,886 | 97,806 | +2.00% | +0.79% | +1.21% |

Being direct about what this does and does not show:

- **At 20 middleware the improvement is consistent** and larger than the control drift, about 0.3 µs per request across the traced call sites.
- **At 6 middleware, closer to a default kernel, it is at the noise floor.** Two runs landed on opposite sides of zero. Both are recorded, including the negative one. I would not quote a number there.
- **With no middleware there is nothing measurable**, which is expected: only four call sites remain.

What is removed is a fixed cost per instrumented call site rather than a share of the work a middleware performs, so the saving grows with the number of middleware, not with how heavy they are. An application with a long middleware stack benefits; a thin one will not notice.

The run-to-run drift on my machine is comparable to the effect at low middleware counts, so anyone reproducing this should run both revisions more than once and report the control.

- Environment: Apple M4, 32 GiB, Node 24.19.0, 100 connections, pipelining 10
- Full tables and raw JSON: [`benchmarks/results/router-comparison.md`](https://github.com/adonisjs/http-server/blob/perf/skip-unused-tracing/benchmarks/results/router-comparison.md)
