### PR TITLE
fix(response): preserve native response cookies

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -861,7 +861,17 @@ export class HttpResponse extends Macroable {
    */
   send(body: any, generateEtag: boolean = this.#config.etag): void {
     if (body instanceof Response) {
-      body.headers.forEach((value, key) => this.header(key, value))
+      body.headers.forEach((value, key) => {
+        if (key !== 'set-cookie') {
+          this.header(key, value)
+        }
+      })
+
+      const cookies = body.headers.getSetCookie()
+      if (cookies.length) {
+        this.append('set-cookie', cookies)
+      }
+
       this.safeStatus(body.status)
 
       if (body.body) {

--- a/tests/response.spec.ts
+++ b/tests/response.spec.ts
@@ -1608,4 +1608,47 @@ test.group('Response', (group) => {
     assert.property(headers, 'x-powered-by')
     assert.equal(headers['x-powered-by'], 'adonisjs')
   })
+
+  test('preserve multiple Set-Cookie headers from a web-native Response', async ({ assert }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const response = new HttpResponseFactory().merge({ req, res, encryption, router }).create()
+      response.send(
+        new Response('ok', {
+          headers: [
+            ['Set-Cookie', 'first=1; Path=/'],
+            ['Set-Cookie', 'second=2; Path=/'],
+          ],
+        })
+      )
+      response.finish()
+    })
+
+    const { headers } = await supertest(url).get('/').expect(200)
+    assert.deepEqual(headers['set-cookie'], ['first=1; Path=/', 'second=2; Path=/'])
+  })
+
+  test('merge Set-Cookie headers from a web-native Response with existing headers', async ({
+    assert,
+  }) => {
+    const { url } = await httpServer.create((req, res) => {
+      const response = new HttpResponseFactory().merge({ req, res, encryption, router }).create()
+      response.append('Set-Cookie', 'framework=1; Path=/')
+      response.send(
+        new Response('ok', {
+          headers: [
+            ['Set-Cookie', 'native-a=1; Path=/'],
+            ['Set-Cookie', 'native-b=2; Path=/'],
+          ],
+        })
+      )
+      response.finish()
+    })
+
+    const { headers } = await supertest(url).get('/').expect(200)
+    assert.deepEqual(headers['set-cookie'], [
+      'framework=1; Path=/',
+      'native-a=1; Path=/',
+      'native-b=2; Path=/',
+    ])
+  })
 })


### PR DESCRIPTION
## Problem
When `HttpResponse#send()` receives a web-native `Response`, its multiple `Set-Cookie` headers are collapsed into one. The native cookie also replaces cookies already set through Adonis response APIs.

## Fix
Read cookies with `Headers#getSetCookie()` and append them separately, preserving all native cookies and existing response cookies.

## Testing
- npm run quick:test
- npm run typecheck
- npm run lint